### PR TITLE
Upgrade to scalatest 3.2, scalacheck 1.15

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -5,8 +5,7 @@ val scala211  = "2.11.12"
 val scala212  = "2.12.10"
 val scala213  = "2.13.1"
 val scala3    = "3.0.0-M2"
-val scalaJS06 = "0.6.32"
-val scalaJS1  = "1.0.0"
+val scalaJS1  = "1.3.1"
 
 val dottyCustomVersion = Option(sys.props("dottyVersion"))
 
@@ -16,8 +15,6 @@ val scala2JVMVersions = Seq(scala212, scala213)
 val scalaJVMVersions = scala2JVMVersions ++ Seq(scala3) ++ dottyCustomVersion
 
 val scalaJSVersions = Seq(
-  (scala212, scalaJS06),
-  (scala213, scalaJS06),
   (scala212, scalaJS1),
   (scala213, scalaJS1)
 )
@@ -246,8 +243,8 @@ object ujson extends Module{
     trait JawnTestModule extends CommonTestModule{
       def ivyDeps = T{
         if (!isDotty) Agg(
-          ivy"org.scalatest::scalatest::3.1.1",
-          ivy"org.scalatestplus::scalacheck-1-14::3.1.1.1"
+          ivy"org.scalatest::scalatest::3.2.3",
+          ivy"org.scalatestplus::scalacheck-1-15::3.2.3.0"
         )
         else Agg()
       }

--- a/ujson/test/src-2/ujson/BoolSpec.scala
+++ b/ujson/test/src-2/ujson/BoolSpec.scala
@@ -1,6 +1,7 @@
 package ujson
 
 import org.scalatest._
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import org.scalacheck._
 

--- a/ujson/test/src-2/ujson/CharBuilderSpec.scala
+++ b/ujson/test/src-2/ujson/CharBuilderSpec.scala
@@ -1,6 +1,7 @@
 package ujson
 
 import org.scalatest._
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec._
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 

--- a/ujson/test/src-2/ujson/JNumIndexCheck.scala
+++ b/ujson/test/src-2/ujson/JNumIndexCheck.scala
@@ -2,7 +2,7 @@ package ujson
 
 import java.nio.ByteBuffer
 
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import upickle.core.{ArrVisitor, ObjVisitor, Visitor}

--- a/ujson/test/src-2/ujson/SyntaxCheck.scala
+++ b/ujson/test/src-2/ujson/SyntaxCheck.scala
@@ -5,6 +5,7 @@ import java.nio.charset.StandardCharsets
 
 import org.scalacheck.Gen._
 import org.scalacheck._
+import org.scalatest.matchers.should.Matchers
 import org.scalatest._
 import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks


### PR DESCRIPTION
 And drop support for Scala.js 0.6 as it is no longer supported by
scalacheck.

Also upgrade Scala.js to 1.3 since that's what scalacheck requires.