### PR TITLE
Reduce generated code size of macros by moving generated code into helpers

### DIFF
--- a/core/src/upickle/core/Types.scala
+++ b/core/src/upickle/core/Types.scala
@@ -197,6 +197,7 @@ trait Types{ types =>
           found |= (1L << currentIndex)
         }
       }
+      def visitKey(index: Int) = _root_.upickle.core.StringVisitor
       protected def storeValueIfNotFound(i: Int, v: Any) = {
         if ((found & (1L << i)) == 0) {
           found |= (1L << i)

--- a/core/src/upickle/core/Types.scala
+++ b/core/src/upickle/core/Types.scala
@@ -186,6 +186,7 @@ trait Types{ types =>
 
   abstract class CaseR[V] extends SimpleReader[V]{
     override def expectedMsg = "expected dictionary"
+
     trait CaseObjectContext extends ObjVisitor[Any, V]{
       def storeAggregatedValue(currentIndex: Int, v: Any): Unit
       var found = 0L
@@ -195,6 +196,21 @@ trait Types{ types =>
           storeAggregatedValue(currentIndex, v)
           found |= (1L << currentIndex)
         }
+      }
+      protected def storeValueIfNotFound(i: Int, v: Any) = {
+        if ((found & (1L << i)) == 0) {
+          found |= (1L << i)
+          storeAggregatedValue(i, v)
+        }
+      }
+      protected def errorMissingKeys(rawArgsLength: Int, mappedArgs: Array[String]) = {
+        val keys = for{
+          i <- 0 until rawArgsLength
+          if (found & (1L << i)) == 0
+        } yield mappedArgs(i)
+        throw new _root_.upickle.core.Abort(
+          "missing keys in dictionary: " + keys.mkString(", ")
+        )
       }
     }
   }
@@ -208,6 +224,17 @@ trait Types{ types =>
         writeToObject(ctx, v)
         ctx.visitEnd(-1)
       }
+    }
+    protected def writeSnippet[R, V](objectAttributeKeyWriteMap: CharSequence => CharSequence,
+                                     ctx: _root_.upickle.core.ObjVisitor[_, R],
+                                     mappedArgsI: String,
+                                     w: Writer[V],
+                                     value: V) = {
+      val keyVisitor = ctx.visitKey(-1)
+      ctx.visitKeyValue(
+        keyVisitor.visitString(objectAttributeKeyWriteMap(mappedArgsI), -1)
+      )
+      ctx.narrow.visitValue(w.write(ctx.subVisitor, value), -1)
     }
   }
   class SingletonR[T](t: T) extends CaseR[T]{

--- a/implicits/src-2/upickle/implicits/internal/Macros.scala
+++ b/implicits/src-2/upickle/implicits/internal/Macros.scala
@@ -262,7 +262,7 @@ object Macros {
                 yield cq"$i => ${aggregates(i)} = v.asInstanceOf[${argTypes(i)}]"
               }
             }
-            def visitKey(index: Int) = _root_.upickle.core.StringVisitor
+
             def visitKeyValue(s: Any) = {
               currentIndex = ${c.prefix}.objectAttributeKeyReadMap(s.toString).toString match {
                 case ..${

--- a/implicits/src-2/upickle/implicits/internal/Macros.scala
+++ b/implicits/src-2/upickle/implicits/internal/Macros.scala
@@ -354,20 +354,18 @@ object Macros {
       q"""
         new ${c.prefix}.CaseW[$targetType]{
           def length(v: $targetType) = {
-            var n = 0
-            ..${
-              for(i <- 0 until rawArgs.length)
-              yield {
-                if (!hasDefaults(i)) q"n += 1"
-                else q"""if ($serDfltVals || v.${TermName(rawArgs(i))} != ${defaults(i)}) n += 1"""
-              }
+            ${
+              Range(0, rawArgs.length)
+                .map(i =>
+                  if (!hasDefaults(i)) q"1"
+                  else q"""if ($serDfltVals || v.${TermName(rawArgs(i))} != ${defaults(i)}) 1 else 0"""
+                )
+                .foldLeft[Tree](q"0"){case (prev, next) => q"$prev + $next"}
             }
-            n
           }
           def writeToObject[R](ctx: _root_.upickle.core.ObjVisitor[_, R],
                                v: $targetType): Unit = {
             ..${(0 until rawArgs.length).map(write)}
-
           }
         }
        """

--- a/implicits/src-2/upickle/implicits/internal/Macros.scala
+++ b/implicits/src-2/upickle/implicits/internal/Macros.scala
@@ -276,25 +276,13 @@ object Macros {
             def visitEnd(index: Int) = {
               ..${
                 for(i <- rawArgs.indices if hasDefaults(i))
-                yield q"if ((found & (1L << $i)) == 0) {found |= (1L << $i); storeAggregatedValue($i, ${defaults(i)})}"
+                yield q"this.storeValueIfNotFound($i, ${defaults(i)})"
               }
 
               // Special-case 64 because java bit shifting ignores any RHS values above 63
               // https://docs.oracle.com/javase/specs/jls/se7/html/jls-15.html#jls-15.19
               if (found != ${if (rawArgs.length == 64) -1 else (1L << rawArgs.length) - 1}){
-                var i = 0
-                val keys = for{
-                  i <- 0 until ${rawArgs.length}
-                  if (found & (1L << i)) == 0
-                } yield i match{
-                  case ..${
-                    for (i <- mappedArgs.indices)
-                    yield cq"$i => ${mappedArgs(i)}"
-                  }
-                }
-                throw new _root_.upickle.core.Abort(
-                  "missing keys in dictionary: " + keys.mkString(", ")
-                )
+                this.errorMissingKeys(${rawArgs.length}, ${mappedArgs.toArray})
               }
               $companion.apply(
                 ..${
@@ -351,15 +339,13 @@ object Macros {
 
       def write(i: Int) = {
         val snippet = q"""
-          val keyVisitor = ctx.visitKey(-1)
-          ctx.visitKeyValue(
-            keyVisitor.visitString(
-              ${c.prefix}.objectAttributeKeyWriteMap(${mappedArgs(i)}),
-              -1
-            )
-          )
-          val w = implicitly[${c.prefix}.Writer[${argTypes(i)}]]
-          ctx.narrow.visitValue(w.write(ctx.subVisitor, v.${TermName(rawArgs(i))}), -1)
+          this.writeSnippet[R, ${argTypes(i)}](
+            ${c.prefix}.objectAttributeKeyWriteMap,
+             ctx,
+             ${mappedArgs(i)},
+             implicitly[${c.prefix}.Writer[${argTypes(i)}]],
+             v.${TermName(rawArgs(i))}
+           )
         """
         
         if (!hasDefaults(i)) snippet


### PR DESCRIPTION
This should give us all the "easy" wins, without significant performance impact. Anything further would probably require converting local variables and fields into dynamic dictionaries, which would slow things down considerably