### PR TITLE
Fix: "match may not be exhaustive" scala 2.13 -Xlint warnings

### DIFF
--- a/implicits/src-2/upickle/implicits/internal/Macros.scala
+++ b/implicits/src-2/upickle/implicits/internal/Macros.scala
@@ -259,6 +259,7 @@ object Macros {
                 for (i <- rawArgs.indices)
                 yield cq"$i => ${aggregates(i)} = v.asInstanceOf[${argTypes(i)}]"
               }
+              case _ => throw new java.lang.IndexOutOfBoundsException(currentIndex.toString)
             }
 
             def visitKeyValue(s: Any) = {
@@ -301,6 +302,7 @@ object Macros {
                 for (i <- rawArgs.indices)
                 yield cq"$i => ${localReaders(i)} "
               }
+              case _ => throw new java.lang.IndexOutOfBoundsException(currentIndex.toString)
             }
           }
         }


### PR DESCRIPTION
Fixes #345. Low-effort port of https://github.com/rallyhealth/weePickle/pull/82.