### PR TITLE
Implement `visitFloat32`, `visitFloat64String` for Byte/Short/Int/Long/Float/Double/Char

### DIFF
--- a/implicits/src/upickle/implicits/Readers.scala
+++ b/implicits/src/upickle/implicits/Readers.scala
@@ -42,7 +42,17 @@ trait Readers extends upickle.core.Types
     override def visitUInt64(d: Long, index: Int) = d
     override def visitFloat32(d: Float, index: Int) = d
     override def visitFloat64(d: Double, index: Int) = d
-
+    override def visitFloat64String(s: String, index: Int) = {
+      visitFloat64StringParts(
+        s,
+        s.indexOf('.'),
+        s.indexOf('E') match{
+          case -1 => s.indexOf('e')
+          case n => n
+        },
+        -1
+      )
+    }
     override def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, index: Int) = {
       s.toString.toDouble
     }
@@ -54,6 +64,17 @@ trait Readers extends upickle.core.Types
     override def visitUInt64(d: Long, index: Int) = d.toInt
     override def visitFloat32(d: Float, index: Int) = d.toInt
     override def visitFloat64(d: Double, index: Int) = d.toInt
+    override def visitFloat64String(s: String, index: Int) = {
+      visitFloat64StringParts(
+        s,
+        s.indexOf('.'),
+        s.indexOf('E') match{
+          case -1 => s.indexOf('e')
+          case n => n
+        },
+        -1
+      )
+    }
     override def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, index: Int) = {
       Util.parseIntegralNum(s, decIndex, expIndex, index).toInt
     }
@@ -67,6 +88,17 @@ trait Readers extends upickle.core.Types
     override def visitUInt64(d: Long, index: Int) = d.toFloat
     override def visitFloat32(d: Float, index: Int) = d
     override def visitFloat64(d: Double, index: Int) = d.toFloat
+    override def visitFloat64String(s: String, index: Int) = {
+      visitFloat64StringParts(
+        s,
+        s.indexOf('.'),
+        s.indexOf('E') match{
+          case -1 => s.indexOf('e')
+          case n => n
+        },
+        -1
+      )
+    }
     override def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, index: Int) = {
       s.toString.toFloat
     }
@@ -78,6 +110,17 @@ trait Readers extends upickle.core.Types
     override def visitUInt64(d: Long, index: Int) = d.toShort
     override def visitFloat32(d: Float, index: Int) = d.toShort
     override def visitFloat64(d: Double, index: Int) = d.toShort
+    override def visitFloat64String(s: String, index: Int) = {
+      visitFloat64StringParts(
+        s,
+        s.indexOf('.'),
+        s.indexOf('E') match{
+          case -1 => s.indexOf('e')
+          case n => n
+        },
+        -1
+      )
+    }
     override def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, index: Int) = {
       Util.parseIntegralNum(s, decIndex, expIndex, index).toShort
     }
@@ -89,6 +132,17 @@ trait Readers extends upickle.core.Types
     override def visitUInt64(d: Long, index: Int) = d.toByte
     override def visitFloat32(d: Float, index: Int) = d.toByte
     override def visitFloat64(d: Double, index: Int) = d.toByte
+    override def visitFloat64String(s: String, index: Int) = {
+      visitFloat64StringParts(
+        s,
+        s.indexOf('.'),
+        s.indexOf('E') match{
+          case -1 => s.indexOf('e')
+          case n => n
+        },
+        -1
+      )
+    }
     override def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, index: Int) = {
       Util.parseIntegralNum(s, decIndex, expIndex, index).toByte
     }
@@ -110,7 +164,19 @@ trait Readers extends upickle.core.Types
     override def visitInt32(d: Int, index: Int) = d.toChar
     override def visitInt64(d: Long, index: Int) = d.toChar
     override def visitUInt64(d: Long, index: Int) = d.toChar
+    override def visitFloat32(d: Float, index: Int) = d.toChar
     override def visitFloat64(d: Double, index: Int) = d.toChar
+    override def visitFloat64String(s: String, index: Int) = {
+      visitFloat64StringParts(
+        s,
+        s.indexOf('.'),
+        s.indexOf('E') match{
+          case -1 => s.indexOf('e')
+          case n => n
+        },
+        -1
+      )
+    }
     override def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, index: Int) = {
       Util.parseIntegralNum(s, decIndex, expIndex, index).toChar
     }
@@ -124,6 +190,17 @@ trait Readers extends upickle.core.Types
     override def visitUInt64(d: Long, index: Int) = d.toLong
     override def visitFloat32(d: Float, index: Int) = d.toLong
     override def visitFloat64(d: Double, index: Int) = d.toLong
+    override def visitFloat64String(s: String, index: Int) = {
+      visitFloat64StringParts(
+        s,
+        s.indexOf('.'),
+        s.indexOf('E') match{
+          case -1 => s.indexOf('e')
+          case n => n
+        },
+        -1
+      )
+    }
     override def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, index: Int) = {
       Util.parseIntegralNum(s, decIndex, expIndex, index).toLong
     }

--- a/implicits/src/upickle/implicits/Readers.scala
+++ b/implicits/src/upickle/implicits/Readers.scala
@@ -33,8 +33,21 @@ trait Readers extends upickle.core.Types
     override def visitFalse(index: Int) = false
   }
 
+  protected trait NumericReader[T] extends SimpleReader[T] {
+    override def visitFloat64String(s: String, index: Int) = {
+      visitFloat64StringParts(
+        s,
+        s.indexOf('.'),
+        s.indexOf('E') match{
+          case -1 => s.indexOf('e')
+          case n => n
+        },
+        -1
+      )
+    }
+  }
 
-  implicit val DoubleReader: Reader[Double] = new SimpleReader[Double] {
+  implicit val DoubleReader: Reader[Double] = new NumericReader[Double] {
     override def expectedMsg = "expected number"
     override def visitString(s: CharSequence, index: Int) = s.toString.toDouble
     override def visitInt32(d: Int, index: Int) = d
@@ -42,44 +55,22 @@ trait Readers extends upickle.core.Types
     override def visitUInt64(d: Long, index: Int) = d
     override def visitFloat32(d: Float, index: Int) = d
     override def visitFloat64(d: Double, index: Int) = d
-    override def visitFloat64String(s: String, index: Int) = {
-      visitFloat64StringParts(
-        s,
-        s.indexOf('.'),
-        s.indexOf('E') match{
-          case -1 => s.indexOf('e')
-          case n => n
-        },
-        -1
-      )
-    }
     override def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, index: Int) = {
       s.toString.toDouble
     }
   }
-  implicit val IntReader: Reader[Int] = new SimpleReader[Int] {
+  implicit val IntReader: Reader[Int] = new NumericReader[Int] {
     override def expectedMsg = "expected number"
     override def visitInt32(d: Int, index: Int) = d
     override def visitInt64(d: Long, index: Int) = d.toInt
     override def visitUInt64(d: Long, index: Int) = d.toInt
     override def visitFloat32(d: Float, index: Int) = d.toInt
     override def visitFloat64(d: Double, index: Int) = d.toInt
-    override def visitFloat64String(s: String, index: Int) = {
-      visitFloat64StringParts(
-        s,
-        s.indexOf('.'),
-        s.indexOf('E') match{
-          case -1 => s.indexOf('e')
-          case n => n
-        },
-        -1
-      )
-    }
     override def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, index: Int) = {
       Util.parseIntegralNum(s, decIndex, expIndex, index).toInt
     }
   }
-  implicit val FloatReader: Reader[Float] = new SimpleReader[Float] {
+  implicit val FloatReader: Reader[Float] = new NumericReader[Float] {
     override def expectedMsg = "expected number"
 
     override def visitString(s: CharSequence, index: Int) = s.toString.toFloat
@@ -88,61 +79,28 @@ trait Readers extends upickle.core.Types
     override def visitUInt64(d: Long, index: Int) = d.toFloat
     override def visitFloat32(d: Float, index: Int) = d
     override def visitFloat64(d: Double, index: Int) = d.toFloat
-    override def visitFloat64String(s: String, index: Int) = {
-      visitFloat64StringParts(
-        s,
-        s.indexOf('.'),
-        s.indexOf('E') match{
-          case -1 => s.indexOf('e')
-          case n => n
-        },
-        -1
-      )
-    }
     override def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, index: Int) = {
       s.toString.toFloat
     }
   }
-  implicit val ShortReader: Reader[Short] = new SimpleReader[Short] {
+  implicit val ShortReader: Reader[Short] = new NumericReader[Short] {
     override def expectedMsg = "expected number"
     override def visitInt32(d: Int, index: Int) = d.toShort
     override def visitInt64(d: Long, index: Int) = d.toShort
     override def visitUInt64(d: Long, index: Int) = d.toShort
     override def visitFloat32(d: Float, index: Int) = d.toShort
     override def visitFloat64(d: Double, index: Int) = d.toShort
-    override def visitFloat64String(s: String, index: Int) = {
-      visitFloat64StringParts(
-        s,
-        s.indexOf('.'),
-        s.indexOf('E') match{
-          case -1 => s.indexOf('e')
-          case n => n
-        },
-        -1
-      )
-    }
     override def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, index: Int) = {
       Util.parseIntegralNum(s, decIndex, expIndex, index).toShort
     }
   }
-  implicit val ByteReader: Reader[Byte] = new SimpleReader[Byte] {
+  implicit val ByteReader: Reader[Byte] = new NumericReader[Byte] {
     override def expectedMsg = "expected number"
     override def visitInt32(d: Int, index: Int) = d.toByte
     override def visitInt64(d: Long, index: Int) = d.toByte
     override def visitUInt64(d: Long, index: Int) = d.toByte
     override def visitFloat32(d: Float, index: Int) = d.toByte
     override def visitFloat64(d: Double, index: Int) = d.toByte
-    override def visitFloat64String(s: String, index: Int) = {
-      visitFloat64StringParts(
-        s,
-        s.indexOf('.'),
-        s.indexOf('E') match{
-          case -1 => s.indexOf('e')
-          case n => n
-        },
-        -1
-      )
-    }
     override def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, index: Int) = {
       Util.parseIntegralNum(s, decIndex, expIndex, index).toByte
     }
@@ -157,7 +115,7 @@ trait Readers extends upickle.core.Types
     override def visitString(s: CharSequence, index: Int) = f(s)
   }
 
-  implicit val CharReader: Reader[Char] = new SimpleReader[Char] {
+  implicit val CharReader: Reader[Char] = new NumericReader[Char] {
     override def expectedMsg = "expected char"
     override def visitString(d: CharSequence, index: Int) = d.charAt(0)
     override def visitChar(d: Char, index: Int) = d
@@ -166,23 +124,12 @@ trait Readers extends upickle.core.Types
     override def visitUInt64(d: Long, index: Int) = d.toChar
     override def visitFloat32(d: Float, index: Int) = d.toChar
     override def visitFloat64(d: Double, index: Int) = d.toChar
-    override def visitFloat64String(s: String, index: Int) = {
-      visitFloat64StringParts(
-        s,
-        s.indexOf('.'),
-        s.indexOf('E') match{
-          case -1 => s.indexOf('e')
-          case n => n
-        },
-        -1
-      )
-    }
     override def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, index: Int) = {
       Util.parseIntegralNum(s, decIndex, expIndex, index).toChar
     }
   }
   implicit val UUIDReader: Reader[UUID] = new MapStringReader(s => UUID.fromString(s.toString))
-  implicit val LongReader: Reader[Long] = new SimpleReader[Long] {
+  implicit val LongReader: Reader[Long] = new NumericReader[Long] {
     override def expectedMsg = "expected number"
     override def visitString(d: CharSequence, index: Int) = upickle.core.Util.parseLong(d, 0, d.length())
     override def visitInt32(d: Int, index: Int) = d.toLong
@@ -190,17 +137,6 @@ trait Readers extends upickle.core.Types
     override def visitUInt64(d: Long, index: Int) = d.toLong
     override def visitFloat32(d: Float, index: Int) = d.toLong
     override def visitFloat64(d: Double, index: Int) = d.toLong
-    override def visitFloat64String(s: String, index: Int) = {
-      visitFloat64StringParts(
-        s,
-        s.indexOf('.'),
-        s.indexOf('E') match{
-          case -1 => s.indexOf('e')
-          case n => n
-        },
-        -1
-      )
-    }
     override def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, index: Int) = {
       Util.parseIntegralNum(s, decIndex, expIndex, index).toLong
     }

--- a/implicits/src/upickle/implicits/Readers.scala
+++ b/implicits/src/upickle/implicits/Readers.scala
@@ -40,6 +40,7 @@ trait Readers extends upickle.core.Types
     override def visitInt32(d: Int, index: Int) = d
     override def visitInt64(d: Long, index: Int) = d
     override def visitUInt64(d: Long, index: Int) = d
+    override def visitFloat32(d: Float, index: Int) = d
     override def visitFloat64(d: Double, index: Int) = d
 
     override def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, index: Int) = {
@@ -51,6 +52,7 @@ trait Readers extends upickle.core.Types
     override def visitInt32(d: Int, index: Int) = d
     override def visitInt64(d: Long, index: Int) = d.toInt
     override def visitUInt64(d: Long, index: Int) = d.toInt
+    override def visitFloat32(d: Float, index: Int) = d.toInt
     override def visitFloat64(d: Double, index: Int) = d.toInt
     override def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, index: Int) = {
       Util.parseIntegralNum(s, decIndex, expIndex, index).toInt
@@ -63,6 +65,7 @@ trait Readers extends upickle.core.Types
     override def visitInt32(d: Int, index: Int) = d.toFloat
     override def visitInt64(d: Long, index: Int) = d.toFloat
     override def visitUInt64(d: Long, index: Int) = d.toFloat
+    override def visitFloat32(d: Float, index: Int) = d
     override def visitFloat64(d: Double, index: Int) = d.toFloat
     override def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, index: Int) = {
       s.toString.toFloat
@@ -73,6 +76,7 @@ trait Readers extends upickle.core.Types
     override def visitInt32(d: Int, index: Int) = d.toShort
     override def visitInt64(d: Long, index: Int) = d.toShort
     override def visitUInt64(d: Long, index: Int) = d.toShort
+    override def visitFloat32(d: Float, index: Int) = d.toShort
     override def visitFloat64(d: Double, index: Int) = d.toShort
     override def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, index: Int) = {
       Util.parseIntegralNum(s, decIndex, expIndex, index).toShort
@@ -83,6 +87,7 @@ trait Readers extends upickle.core.Types
     override def visitInt32(d: Int, index: Int) = d.toByte
     override def visitInt64(d: Long, index: Int) = d.toByte
     override def visitUInt64(d: Long, index: Int) = d.toByte
+    override def visitFloat32(d: Float, index: Int) = d.toByte
     override def visitFloat64(d: Double, index: Int) = d.toByte
     override def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, index: Int) = {
       Util.parseIntegralNum(s, decIndex, expIndex, index).toByte
@@ -117,6 +122,7 @@ trait Readers extends upickle.core.Types
     override def visitInt32(d: Int, index: Int) = d.toLong
     override def visitInt64(d: Long, index: Int) = d.toLong
     override def visitUInt64(d: Long, index: Int) = d.toLong
+    override def visitFloat32(d: Float, index: Int) = d.toLong
     override def visitFloat64(d: Double, index: Int) = d.toLong
     override def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, index: Int) = {
       Util.parseIntegralNum(s, decIndex, expIndex, index).toLong

--- a/upickle/test/src/upickle/PrimitiveTests.scala
+++ b/upickle/test/src/upickle/PrimitiveTests.scala
@@ -32,12 +32,12 @@ object PrimitiveTests extends TestSuite {
       }
     }
     test("Long"){
-      test("small") - rw(1: Long, """ "1" """)
-      test("med") - rw(125123: Long, """ "125123" """)
-      test("min") - rw(Int.MinValue.toLong - 1, """ "-2147483649" """)
-      test("max") - rw(Int.MaxValue.toLong + 1, """ "2147483648" """)
-      test("min") - rw(Long.MinValue, """ "-9223372036854775808" """)
-      test("max") - rw(Long.MaxValue, """ "9223372036854775807" """)
+      test("small") - rwNum(1: Long, """ "1" """)
+      test("med") - rwNum(125123: Long, """ "125123" """)
+      test("min") - rwNum(Int.MinValue.toLong - 1, """ "-2147483649" """)
+      test("max") - rwNum(Int.MaxValue.toLong + 1, """ "2147483648" """)
+      test("min") - rwNum(Long.MinValue, """ "-9223372036854775808" """)
+      test("max") - rwNum(Long.MaxValue, """ "9223372036854775807" """)
       test("null") - assert(read[Long]("null") == 0)
     }
     test("BigInt"){
@@ -60,18 +60,18 @@ object PrimitiveTests extends TestSuite {
     }
 
     test("Int"){
-      test("small") - rw(1, "1")
-      test("med") - rw(125123, "125123")
-      test("min") - rw(Int.MinValue, "-2147483648")
-      test("max") - rw(Int.MaxValue, "2147483647")
+      test("small") - rwNum(1, "1")
+      test("med") - rwNum(125123, "125123")
+      test("min") - rwNum(Int.MinValue, "-2147483648")
+      test("max") - rwNum(Int.MaxValue, "2147483647")
       test("null") - assert(read[Int]("null") == 0)
     }
 
     test("Double"){
-      test("whole") - rw(125123: Double, """125123.0""", """125123""")
-      test("wholeLarge") - rw(1475741505173L: Double, """1475741505173.0""", """1475741505173""")
-      test("fractional") - rw(125123.1542312, """125123.1542312""")
-      test("negative") - rw(-125123.1542312, """-125123.1542312""")
+      test("whole") - rwNum(125123: Double, """125123.0""", """125123""")
+      test("wholeLarge") - rwNum(1475741505173L: Double, """1475741505173.0""", """1475741505173""")
+      test("fractional") - rwNum(125123.1542312, """125123.1542312""")
+      test("negative") - rwNum(-125123.1542312, """-125123.1542312""")
       test("null") - assert(read[Double]("null") == 0.0)
       test("nan") - assert(
         java.lang.Double.isNaN(read[Double](""" "NaN" """)),
@@ -84,32 +84,32 @@ object PrimitiveTests extends TestSuite {
     }
 
     test("Short"){
-      test("simple") - rw(25123: Short, "25123")
-      test("min") - rw(Short.MinValue, "-32768")
-      test("max") - rw(Short.MaxValue, "32767")
+      test("simple") - rwNum(25123: Short, "25123")
+      test("min") - rwNum(Short.MinValue, "-32768")
+      test("max") - rwNum(Short.MaxValue, "32767")
       test("null") - assert(read[Short]("null") == 0)
       test("all"){
-        for (i <- Short.MinValue to Short.MaxValue) rw(i)
+        for (i <- Short.MinValue to Short.MaxValue) rwNum(i)
       }
     }
 
     test("Byte"){
-      test("simple") - rw(125: Byte, "125")
-      test("min") - rw(Byte.MinValue, "-128")
-      test("max") - rw(Byte.MaxValue, "127")
+      test("simple") - rwNum(125: Byte, "125")
+      test("min") - rwNum(Byte.MinValue, "-128")
+      test("max") - rwNum(Byte.MaxValue, "127")
       test("null") - assert(read[Byte]("null") == 0)
       test("all"){
-        for (i <- Byte.MinValue to Byte.MaxValue) rw(i)
+        for (i <- Byte.MinValue to Byte.MaxValue) rwNum(i)
       }
     }
 
     test("Float"){
-      test("simple") - rw(125.125f, """125.125""")
-      test("max") - rw(Float.MaxValue)
-      test("min") - rw(Float.MinValue)
-      test("minPos") - rw(Float.MinPositiveValue)
-      test("inf") - rw(Float.PositiveInfinity, """ "Infinity" """)
-      "neg-inf" - rw(Float.NegativeInfinity, """ "-Infinity" """)
+      test("simple") - rwNum(125.125f, """125.125""")
+      test("max") - rwNum(Float.MaxValue)
+      test("min") - rwNum(Float.MinValue)
+      test("minPos") - rwNum(Float.MinPositiveValue)
+      test("inf") - rwNum(Float.PositiveInfinity, """ "Infinity" """)
+      "neg-inf" - rwNum(Float.NegativeInfinity, """ "-Infinity" """)
       test("null") - assert(read[Float]("null") == 0.0)
       test("nan") - assert(
         java.lang.Float.isNaN(read[Float](""" "NaN" """)),
@@ -122,7 +122,10 @@ object PrimitiveTests extends TestSuite {
       test("plus") - rwNoBinaryJson('+', """ "+" """)
 
       test("all"){
-        for(i <- Char.MinValue until 55296/*Char.MaxValue*/) rwNoBinaryJson(i)
+        for(i <- Char.MinValue until 55296/*Char.MaxValue*/) {
+          rwNoBinaryJson(i)
+          num(i)
+        }
       }
     }
   }

--- a/upickle/test/src/upickle/TestUtil.scala
+++ b/upickle/test/src/upickle/TestUtil.scala
@@ -5,6 +5,8 @@ package upickle
 import java.io.ByteArrayInputStream
 import java.nio.charset.StandardCharsets
 
+import scala.Numeric.Implicits._
+
 import utest.{assert => _, _}
 /**
 * Created by haoyi on 4/22/14.
@@ -94,5 +96,18 @@ class TestUtil[Api <: upickle.Api](val api: Api){
       val rewrittenBinaryStr = upickle.core.Util.bytesToString(rewrittenBinary)
       utest.assert(writtenBinaryStr == rewrittenBinaryStr)
     }
+  }
+
+  def rwNum[T: Numeric: api.Reader: api.Writer](t: T, strings: String*) = {
+    rw(t, strings: _*)
+    num(t)
+  }
+
+  def num[T: Numeric : api.Reader](t: T) = {
+    api.reader[T].visitFloat32(t.toFloat, -1) ==> t.toFloat
+    api.reader[T].visitFloat64(t.toDouble, -1) ==> t.toDouble
+    api.reader[T].visitInt32(t.toInt, -1) ==> t.toInt
+    api.reader[T].visitInt64(t.toLong, -1) ==> t.toLong
+    api.reader[T].visitFloat64String(t.toLong.toString, -1) ==> t.toLong
   }
 }


### PR DESCRIPTION
Fixes #354.