### PR TITLE
BugFix: Util.parseLong

### DIFF
--- a/core/src/upickle/core/Util.scala
+++ b/core/src/upickle/core/Util.scala
@@ -63,7 +63,7 @@ object Util {
 
     intPortion + decPortion
   }
-  def parseLong(cs: CharSequence, start: Int, len: Int): Long = {
+  def parseLong(cs: CharSequence, start: Int, end: Int): Long = {
 
     // we store the inverse of the positive sum, to ensure we don't
     // incorrectly overflow on Long.MinValue. for positive numbers
@@ -71,9 +71,8 @@ object Util {
     var inverseSum: Long = 0L
     var inverseSign: Long = -1L
     var i: Int = start
-    val end = start + len
 
-    if ((start | len | (cs.length - end)) < 0) throw new IndexOutOfBoundsException
+    if ((start | end | (cs.length - end)) < 0) throw new IndexOutOfBoundsException
 
     if (cs.charAt(start) == '-') {
       inverseSign = 1L

--- a/core/src/upickle/core/Util.scala
+++ b/core/src/upickle/core/Util.scala
@@ -72,7 +72,7 @@ object Util {
     var inverseSign: Long = -1L
     var i: Int = start
 
-    if ((start | end | (cs.length - end)) < 0) throw new IndexOutOfBoundsException
+    if ((start | end | end - start | (cs.length - end)) < 0) throw new IndexOutOfBoundsException
 
     if (cs.charAt(start) == '-') {
       inverseSign = 1L

--- a/core/src/upickle/core/Util.scala
+++ b/core/src/upickle/core/Util.scala
@@ -71,26 +71,28 @@ object Util {
     var inverseSum: Long = 0L
     var inverseSign: Long = -1L
     var i: Int = start
+    val end = start + len
+
+    if ((start | len | (cs.length - end)) < 0) throw new IndexOutOfBoundsException
 
     if (cs.charAt(start) == '-') {
       inverseSign = 1L
-      i = 1
+      i += 1
     }
 
-    val size = len - i
-    if (i >= len) throw new NumberFormatException(cs.toString)
-    if (size > 19) throw new NumberFormatException(cs.toString)
+    val size = end - i
+    if (size <= 0 || size > 19) throw new NumberFormatException(cs.toString.substring(start, end))
 
-    while (i < len) {
+    while (i < end) {
       val digit = cs.charAt(i).toInt - 48
-      if (digit < 0 || 9 < digit) new NumberFormatException(cs.toString)
+      if (digit < 0 || 9 < digit) throw new NumberFormatException(cs.toString.substring(start, end))
       inverseSum = inverseSum * 10L - digit
       i += 1
     }
 
     // detect and throw on overflow
     if (size == 19 && (inverseSum >= 0 || (inverseSum == Long.MinValue && inverseSign < 0))) {
-      throw new NumberFormatException(cs.toString)
+      throw new NumberFormatException(cs.toString.substring(start, end))
     }
 
     inverseSum * inverseSign

--- a/core/test/src/upickle/core/UtilTests.scala
+++ b/core/test/src/upickle/core/UtilTests.scala
@@ -1,0 +1,53 @@
+package upickle.core
+
+import utest._
+
+import scala.util.Try
+
+object UtilTests extends TestSuite {
+
+  val tests = Tests {
+
+    test("parseLong") {
+
+      test("valid") {
+        test("0")(Util.parseLong("0", 0, 1) ==> 0L)
+        test("42")(Util.parseLong("42", 0, 2) ==> 42L)
+        test("x0")(Util.parseLong("x0", 1, 1) ==> 0L)
+        test("x0x")(Util.parseLong("x0x", 1, 1) ==> 0L)
+        test("x-1x")(Util.parseLong("x-1x", 1, 2) ==> -1L)
+      }
+
+      test("invalid") {
+        def invalid(input: String)(start: Int = 0, len: Int = input.length) = {
+          val e = intercept[NumberFormatException] {
+            Util.parseLong(input, start, len)
+          }
+          e.getMessage ==> input.substring(start, start + len)
+        }
+
+        test("a")(invalid("a")())
+        test("-")(invalid("-")())
+        test("᥌")(invalid("᥌")())
+        test("too long")(invalid(Long.MaxValue.toString + "1")())
+        test("10x")(invalid("x10x")(1, 3))
+        test("x10")(invalid("x10x")(0, 3))
+      }
+
+      test("bounds") {
+        for {
+          start <- -1 to 5
+          len <- -1 to 5
+          if len != 0 // NFE, not IndexOutOfBoundsException
+        } {
+          val s = "111"
+          if (Try(s.substring(start, start + len)).isSuccess) {
+            Util.parseLong(s, start, len)
+          } else {
+            intercept[IndexOutOfBoundsException](Util.parseLong(s, start, len))
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/test/src/upickle/core/UtilTests.scala
+++ b/core/test/src/upickle/core/UtilTests.scala
@@ -33,13 +33,15 @@ object UtilTests extends TestSuite {
     }
 
     test("parseLong - bounds") {
+      val s = "123"
       for {
-        start <- -1 to 5
-          end <- -1 to 5
+        start <- -1 to (s.length + 1)
+          end <- -1 to (s.length + 1)
           if start != end // NumberFormatException, not IndexOutOfBoundsException
       } {
-        val s = "123"
-        if (Try(s.substring(start, end)).isSuccess) {
+        // Roundabout way to avoid scala.js differences: https://github.com/scala-js/scala-js/issues/3546
+        val isValidRange = Try(s.substring(start, end)).toOption.exists(_.length == end - start)
+        if (isValidRange) {
           Util.parseLong(s, start, end)
         } else {
           intercept[IndexOutOfBoundsException](Util.parseLong(s, start, end))

--- a/core/test/src/upickle/core/UtilTests.scala
+++ b/core/test/src/upickle/core/UtilTests.scala
@@ -8,44 +8,41 @@ object UtilTests extends TestSuite {
 
   val tests = Tests {
 
-    test("parseLong") {
+    test("parseLong - valid") {
+      test("0")(Util.parseLong("0", 0, 1) ==> 0L)
+      test("42")(Util.parseLong("42", 0, 2) ==> 42L)
+      test("x0")(Util.parseLong("x0", 1, 2) ==> 0L)
+      test("x0x")(Util.parseLong("x0x", 1, 2) ==> 0L)
+      test("x-1x")(Util.parseLong("x-1x", 1, 3) ==> -1L)
+    }
 
-      test("valid") {
-        test("0")(Util.parseLong("0", 0, 1) ==> 0L)
-        test("42")(Util.parseLong("42", 0, 2) ==> 42L)
-        test("x0")(Util.parseLong("x0", 1, 1) ==> 0L)
-        test("x0x")(Util.parseLong("x0x", 1, 1) ==> 0L)
-        test("x-1x")(Util.parseLong("x-1x", 1, 2) ==> -1L)
-      }
-
-      test("invalid") {
-        def invalid(input: String)(start: Int = 0, len: Int = input.length) = {
-          val e = intercept[NumberFormatException] {
-            Util.parseLong(input, start, len)
-          }
-          e.getMessage ==> input.substring(start, start + len)
+    test("parseLong - invalid") {
+      def invalid(input: String)(start: Int = 0, end: Int = input.length) = {
+        val e = intercept[NumberFormatException] {
+          Util.parseLong(input, start, end)
         }
-
-        test("a")(invalid("a")())
-        test("-")(invalid("-")())
-        test("᥌")(invalid("᥌")())
-        test("too long")(invalid(Long.MaxValue.toString + "1")())
-        test("10x")(invalid("x10x")(1, 3))
-        test("x10")(invalid("x10x")(0, 3))
+        e.getMessage ==> input.substring(start, end)
       }
 
-      test("bounds") {
-        for {
-          start <- -1 to 5
-          len <- -1 to 5
-          if len != 0 // NFE, not IndexOutOfBoundsException
-        } {
-          val s = "111"
-          if (Try(s.substring(start, start + len)).isSuccess) {
-            Util.parseLong(s, start, len)
-          } else {
-            intercept[IndexOutOfBoundsException](Util.parseLong(s, start, len))
-          }
+      test("a")(invalid("a")())
+      test("-")(invalid("-")())
+      test("᥌")(invalid("᥌")())
+      test("too long")(invalid(Long.MaxValue.toString + "1")())
+      test("10x")(invalid("x10x")(1, 4))
+      test("x10")(invalid("x10x")(0, 3))
+    }
+
+    test("parseLong - bounds") {
+      for {
+        start <- -1 to 5
+          end <- -1 to 5
+          if start != end // NumberFormatException, not IndexOutOfBoundsException
+      } {
+        val s = "123"
+        if (Try(s.substring(start, end)).isSuccess) {
+          Util.parseLong(s, start, end)
+        } else {
+          intercept[IndexOutOfBoundsException](Util.parseLong(s, start, end))
         }
       }
     }

--- a/upickle/test/src/upickle/PrimitiveTests.scala
+++ b/upickle/test/src/upickle/PrimitiveTests.scala
@@ -39,6 +39,7 @@ object PrimitiveTests extends TestSuite {
       test("min") - rwNum(Long.MinValue, """ "-9223372036854775808" """)
       test("max") - rwNum(Long.MaxValue, """ "9223372036854775807" """)
       test("null") - assert(read[Long]("null") == 0)
+      test("invalid") - intercept[NumberFormatException](upickle.default.transform("a").to[Long])
     }
     test("BigInt"){
       test("whole") - rw(BigInt("125123"), """ "125123" """)


### PR DESCRIPTION
Currently:
```scala
upickle.default.read[Long](""""a"""") ==> 49L
```

Port of https://github.com/rallyhealth/weePickle/pull/88.
