### PR TITLE
MsgPackReader: properly increment index in `ext`

### DIFF
--- a/upack/src/upack/Msg.scala
+++ b/upack/src/upack/Msg.scala
@@ -128,7 +128,13 @@ object Obj{
 
   def apply(): Obj = Obj(new mutable.LinkedHashMap[Msg, Msg]())
 }
-case class Ext(tag: Byte, data: Array[Byte]) extends Msg
+case class Ext(tag: Byte, data: Array[Byte]) extends Msg {
+  override def equals(other: Any): Boolean = other match {
+    case Ext(tagOther, dataOther) =>
+      tag == tagOther && java.util.Arrays.equals(data, dataOther)
+    case _ => false
+  }
+}
 
 sealed abstract class Bool extends Msg{
   def value: Boolean

--- a/upack/src/upack/Msg.scala
+++ b/upack/src/upack/Msg.scala
@@ -128,16 +128,7 @@ object Obj{
 
   def apply(): Obj = Obj(new mutable.LinkedHashMap[Msg, Msg]())
 }
-case class Ext(tag: Byte, data: Array[Byte]) extends Msg {
-  override def equals(other: Any): Boolean = other match {
-    case Ext(tagOther, dataOther) =>
-      tag == tagOther && java.util.Arrays.equals(data, dataOther)
-    case _ => false
-  }
-
-  override def hashCode: Int =
-    MurmurHash3.bytesHash(b, "Ext".hashCode)
-}
+case class Ext(tag: Byte, data: Array[Byte]) extends Msg
 
 sealed abstract class Bool extends Msg{
   def value: Boolean

--- a/upack/src/upack/Msg.scala
+++ b/upack/src/upack/Msg.scala
@@ -134,6 +134,9 @@ case class Ext(tag: Byte, data: Array[Byte]) extends Msg {
       tag == tagOther && java.util.Arrays.equals(data, dataOther)
     case _ => false
   }
+
+  override def hashCode: Int =
+    MurmurHash3.bytesHash(b, "Ext".hashCode)
 }
 
 sealed abstract class Bool extends Msg{

--- a/upack/src/upack/MsgPackReader.scala
+++ b/upack/src/upack/MsgPackReader.scala
@@ -98,7 +98,9 @@ abstract class BaseMsgPackReader extends upickle.core.BufferingByteParser{
   }
   def parseExt[T](n: Int, visitor: Visitor[_, T]) = {
     val (arr, i, j) = sliceArr(index + 1, n)
-    visitor.visitExt(getByteSafe(index), arr, i, j, index)
+    val res = visitor.visitExt(getByteSafe(index), arr, i, j, index)
+    index += n + 1
+    res
   }
 
   def parseStr[T](n: Int, visitor: Visitor[_, T]) = {

--- a/upack/test/src/upack/UnitTests.scala
+++ b/upack/test/src/upack/UnitTests.scala
@@ -68,5 +68,21 @@ object UnitTests extends TestSuite{
       val parsed = upack.read(bytes)
       assert(msg == parsed)
     }
+    test("extInMap"){
+      val msg = Obj(Str("foo") -> Ext(33, new Array[Byte](12)), Str("bar") -> Null)
+      val out = new ByteArrayOutputStream()
+      msg.writeBytesTo(out)
+      val bytes = out.toByteArray
+      val parsed = upack.read(bytes)
+      assert(msg == parsed)
+    }
+    test("extInList"){
+      val msg = Arr(upack.Ext(33, new Array[Byte](4)), upack.False)
+      val out = new ByteArrayOutputStream()
+      msg.writeBytesTo(out)
+      val bytes = out.toByteArray
+      val parsed = upack.read(bytes)
+      assert(msg == parsed)
+    }
   }
 }

--- a/upack/test/src/upack/UnitTests.scala
+++ b/upack/test/src/upack/UnitTests.scala
@@ -70,19 +70,17 @@ object UnitTests extends TestSuite{
     }
     test("extInMap"){
       val msg = Obj(Str("foo") -> Ext(33, new Array[Byte](12)), Str("bar") -> Null)
-      val out = new ByteArrayOutputStream()
-      msg.writeBytesTo(out)
-      val bytes = out.toByteArray
-      val parsed = upack.read(bytes)
-      assert(msg == parsed)
+      val bytes1 = upack.write(msg)
+      val parsed = upack.read(bytes1)
+      val bytes2 = upack.write(parsed)
+      assert(bytes1 sameElements bytes2)
     }
     test("extInList"){
       val msg = Arr(upack.Ext(33, new Array[Byte](4)), upack.False)
-      val out = new ByteArrayOutputStream()
-      msg.writeBytesTo(out)
-      val bytes = out.toByteArray
-      val parsed = upack.read(bytes)
-      assert(msg == parsed)
+      val bytes1 = upack.write(msg)
+      val parsed = upack.read(bytes1)
+      val bytes2 = upack.write(parsed)
+      assert(bytes1 sameElements bytes2)
     }
   }
 }


### PR DESCRIPTION
The `parseExt` helper in `MsgPackReader` was not properly updating the
position in the data source.

Added two regression tests. These compare serialized and re-serialized
values (instead of just initial and serialized) since structurally identical `Ext`
messages won't compare identical (due to the `Array[Byte]` field whose
equality is determined by identity).

Fixes #369