### PR TITLE
Bugfix: Scala 3 enums (#356)

### DIFF
--- a/implicits/src-3/upickle/implicits/MacroImplicits.scala
+++ b/implicits/src-3/upickle/implicits/MacroImplicits.scala
@@ -2,15 +2,25 @@ package upickle.implicits
 
 import deriving.Mirror
 import scala.reflect.ClassTag
+import scala.compiletime.erasedValue
 
 trait MacroImplicits extends Readers with Writers with upickle.core.Annotator:
   this: upickle.core.Types =>
 
   inline def macroRW[T: ClassTag](using Mirror.Of[T]): ReadWriter[T] =
-    ReadWriter.join(
-      macroR[T],
-      macroW[T]
-    )
+    inline erasedValue[T] match {
+      case _: scala.reflect.Enum =>
+        ReadWriter.join(
+          macroEnumR[T],
+          macroEnumW[T]
+        )
+      case _ =>
+        ReadWriter.join(
+          macroR[T],
+          macroW[T]
+        )
+    }
+
   end macroRW
 
 

--- a/implicits/src-3/upickle/implicits/macros.scala
+++ b/implicits/src-3/upickle/implicits/macros.scala
@@ -84,3 +84,34 @@ def fullClassNameImpl[T](using Quotes, Type[T]): Expr[String] =
     case None => Expr(sym.fullName.replace("$", ""))
   }
 end fullClassNameImpl
+
+inline def enumValueOf[T]: String => T = ${ enumValueOfImpl[T] }
+def enumValueOfImpl[T](using Quotes, Type[T]): Expr[String => T] =
+  import quotes.reflect._
+
+  val sym = TypeTree.of[T].symbol
+  val companion = sym.companionClass.tree.asInstanceOf[ClassDef]
+
+  val valueOfMethod: DefDef = companion.body.collectFirst {
+    case dd @ DefDef("valueOf", _, _, _) => dd
+  }.getOrElse {
+    throw Exception("Enumeration valueOf method not found")
+  }
+
+  val methodSymbol = valueOfMethod.symbol
+  Ref(methodSymbol).etaExpand(methodSymbol.owner).asExpr.asInstanceOf[Expr[String => T]]
+end enumValueOfImpl
+
+case class EnumDescription(name: String, values: Seq[String]) {
+  def pretty = s"$name[values: ${values.mkString(", ")}]"
+}
+
+inline def enumDescription[T](using m: Mirror.Of[T]): EnumDescription = inline m match {
+  case m: Mirror.ProductOf[T] =>
+    throw new UnsupportedOperationException("Products cannot have enum descriptions")
+
+  case m: Mirror.SumOf[T] =>
+    val name = constValue[m.MirroredLabel]
+    val values = constValueTuple[m.MirroredElemLabels].productIterator.toSeq.map(_.toString)
+    EnumDescription(name, values)
+}

--- a/upickle/test/src-3/upickle/Derivation.scala
+++ b/upickle/test/src-3/upickle/Derivation.scala
@@ -73,7 +73,7 @@ object DerivationTests extends TestSuite {
       assert(result == expected)
     }
 
-    test("readWritrer") - {
+    test("readWriter") - {
       val rw = summon[ReadWriter[Animal]]
       val person = Person("Peter", "Somewhere", 30)
       val json = write(person)(rw)

--- a/upickle/test/src-3/upickle/EnumTests.scala
+++ b/upickle/test/src-3/upickle/EnumTests.scala
@@ -1,0 +1,43 @@
+package upickle
+
+import ujson.ParseException
+import upickle.core.AbortException
+
+import scala.language.implicitConversions
+import utest.{assert, intercept, *}
+import upickle.default.*
+
+
+enum SimpleEnum derives ReadWriter:
+  case A, B
+
+case class Enclosing(str: String, simple1: SimpleEnum, simple2: Option[SimpleEnum]) derives ReadWriter
+
+object EnumTests extends TestSuite {
+  val tests = Tests {
+    test("simple") {
+      test("enum write") - {
+        assert(write(SimpleEnum.A) == "\"A\"")
+        assert(write(SimpleEnum.B) == "\"B\"")
+      }
+
+      test("enum read") - {
+        assert(read[SimpleEnum]("\"A\"") == SimpleEnum.A)
+        assert(read[SimpleEnum]("\"B\"") == SimpleEnum.B)
+      }
+
+      test("enum read failure") - {
+        val ex = intercept[AbortException] { read[SimpleEnum]("\"C\"") }
+        val expectedMessage = "Value 'C' was not found in enumeration SimpleEnum[values: A, B] at index 0"
+        assert(ex.getMessage == expectedMessage)
+      }
+
+      test("enclosing write") - {
+        val written = write(Enclosing("test", SimpleEnum.A, Some(SimpleEnum.B)))
+        val expected = """{"str":"test","simple1":"A","simple2":["B"]}"""
+        assert(written == expected)
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
Adds support for scala 3 enumerations which reads/writes them as their canonical string representations (used by the builtin "valueOf" method).