### PR TITLE
Bugfix: Scala 3 generics (#353)

### DIFF
--- a/implicits/src-3/upickle/implicits/macros.scala
+++ b/implicits/src-3/upickle/implicits/macros.scala
@@ -51,10 +51,11 @@ end extractKey
 inline def fieldLabels[T] = ${fieldLabelsImpl[T]}
 def fieldLabelsImpl0[T](using Quotes, Type[T]): List[String] =
   import quotes.reflect._
-  val fields: List[Symbol] = TypeTree.of[T].symbol
+  val fields: List[Symbol] = TypeRepr.of[T].typeSymbol
     .primaryConstructor
     .paramSymss
     .flatten
+    .filterNot(_.isType)
 
   fields.map{ sym =>
     extractKey(sym) match {

--- a/upickle/test/src/upickle/example/ExampleTests.scala
+++ b/upickle/test/src/upickle/example/ExampleTests.scala
@@ -78,6 +78,13 @@ object Custom2{
     )
   }
 }
+object Generic {
+  case class Container[T](a: T)
+  object Container{
+    implicit val intRW: RW[Container[Int]] = macroRW
+  }
+}
+
 
 import KeyedTag._
 import Keyed._
@@ -568,6 +575,23 @@ object ExampleTests extends TestSuite {
 
       writeBinary(Array[Byte](1, 2, 3, 4)) ==> Array(0xc4.toByte, 4, 1, 2, 3, 4)
       readBinary[Array[Byte]](Array[Byte](0xc4.toByte, 4, 1, 2, 3, 4)) ==> Array(1, 2, 3, 4)
+    }
+    test("generic"){
+      import upickle.default._
+      import Generic._
+      test("read") - {
+        val containerJson = """{"a":3}"""
+        val parsed = read[Container[Int]](containerJson)
+        val expected = Container[Int](3)
+        assert(parsed == expected)
+      }
+
+      test("write") - {
+        val original = Container[Int](3)
+        val serialized = write(original)
+        val expected = """{"a":3}"""
+        assert(serialized == expected)
+      }
     }
   }
 }


### PR DESCRIPTION
A small change to `fieldLabelsImpl0` seems to be enough to fix `macroRW` for classes with type parameters in Scala 3. I've added a small regression test as well. 

In the existing implementation, `TypeTree.of[T].symbol` evaluates to `noSymbol` when using a parameterized type. `TypeRepr.of[T].typeSymbol.primaryConstructor.paramSymss` seems to expose the full parameter list including type parameters, so we filter out any type parameters and are left with the constructor fields.

I'm not very confident with compiler internals, in particular not 100% sure I understand the ramifications of using TypeTree vs TypeRepr, so I would appreciate a careful review of this change.