### PR TITLE
Produce a deterministic summoning of subtype reader/writer instances

### DIFF
--- a/implicits/src-2/upickle/implicits/internal/Macros.scala
+++ b/implicits/src-2/upickle/implicits/internal/Macros.scala
@@ -121,7 +121,7 @@ object Macros {
           s"The referenced trait [[${clsSymbol.name}]] does not have any sub-classes. This may " +
             "happen due to a limitation of scalac (SI-7046). To work around this, " +
             "try manually specifying the sealed trait picklers as described in " +
-            "http://www.lihaoyi.com/upickle/#ManualSealedTraitPicklers"
+            "https://com-lihaoyi.github.io/upickle/#ManualSealedTraitPicklers"
         fail(tpe, msg)
       }else{
         val subTypes = fleshedOutSubtypes(tpe).toSeq.sortBy(_.typeSymbol.fullName)

--- a/implicits/src-2/upickle/implicits/internal/Macros.scala
+++ b/implicits/src-2/upickle/implicits/internal/Macros.scala
@@ -124,7 +124,7 @@ object Macros {
             "http://www.lihaoyi.com/upickle/#ManualSealedTraitPicklers"
         fail(tpe, msg)
       }else{
-        val subTypes = fleshedOutSubtypes(tpe).toSeq
+        val subTypes = fleshedOutSubtypes(tpe).toSeq.sortBy(_.typeSymbol.fullName)
         //    println("deriveTrait")
         val subDerives = subTypes.map(subCls => q"implicitly[${typeclassFor(subCls)}]")
         //    println(Console.GREEN + "subDerives " + Console.RESET + subDrivess)


### PR DESCRIPTION
Fixes #390 

This PR sorts the subtypes before summoning them. This fixes the non-deterministic order of the Seq for large ADTs (5 and above subtypes)