### PR TITLE
Add more tests

### DIFF
--- a/upickle/test/src/upickle/MacroTests.scala
+++ b/upickle/test/src/upickle/MacroTests.scala
@@ -106,24 +106,65 @@ object MacroTests extends TestSuite {
     test("commonCustomStructures"){
       test("simpleAdt"){
 
-        test - rw(ADTs.ADT0(), """{}""")
-        test - rw(ADTs.ADTa(1), """{"i":1}""")
-        test - rw(ADTs.ADTb(1, "lol"), """{"i":1,"s":"lol"}""")
+        test - rw(ADTs.ADT0(), """{}""", upack.Obj())
+        test - rw(ADTs.ADTa(1), """{"i":1}""", upack.Obj(upack.Str("i") -> upack.Int32(1)))
+        test - rw(
+          ADTs.ADTb(1, "lol"),
+          """{"i":1,"s":"lol"}""",
+          upack.Obj(upack.Str("i") -> upack.Int32(1), upack.Str("s") -> upack.Str("lol"))
+        )
 
-        test - rw(ADTs.ADTc(1, "lol", (1.1, 1.2)), """{"i":1,"s":"lol","t":[1.1,1.2]}""")
+        test - rw(
+          ADTs.ADTc(1, "lol", (1.1, 1.2)),
+          """{"i":1,"s":"lol","t":[1.1,1.2]}""",
+          upack.Obj(
+            upack.Str("i") -> upack.Int32(1),
+            upack.Str("s") -> upack.Str("lol"),
+            upack.Str("t") -> upack.Arr(upack.Float64(1.1), upack.Float64(1.2))
+          )
+        )
         test - rw(
           ADTs.ADTd(1, "lol", (1.1, 1.2), ADTs.ADTa(1)),
-          """{"i":1,"s":"lol","t":[1.1,1.2],"a":{"i":1}}"""
+          """{"i":1,"s":"lol","t":[1.1,1.2],"a":{"i":1}}""",
+          upack.Obj(
+            upack.Str("i") -> upack.Int32(1),
+            upack.Str("s") -> upack.Str("lol"),
+            upack.Str("t") -> upack.Arr(upack.Float64(1.1), upack.Float64(1.2)),
+            upack.Str("a") -> upack.Obj(upack.Str("i") -> upack.Int32(1))
+          )
         )
 
         test - rw(
           ADTs.ADTe(1, "lol", (1.1, 1.2), ADTs.ADTa(1), List(1.2, 2.1, 3.14)),
-          """{"i":1,"s":"lol","t":[1.1,1.2],"a":{"i":1},"q":[1.2,2.1,3.14]}"""
+          """{"i":1,"s":"lol","t":[1.1,1.2],"a":{"i":1},"q":[1.2,2.1,3.14]}""",
+          upack.Obj(
+            upack.Str("i") -> upack.Int32(1),
+            upack.Str("s") -> upack.Str("lol"),
+            upack.Str("t") -> upack.Arr(upack.Float64(1.1), upack.Float64(1.2)),
+            upack.Str("a") -> upack.Obj(upack.Str("i") -> upack.Int32(1)),
+            upack.Str("q") -> upack.Arr(
+              upack.Float64(1.2),
+              upack.Float64(2.1),
+              upack.Float64(3.14)
+            )
+          )
         )
 
         test - rw(
           ADTs.ADTf(1, "lol", (1.1, 1.2), ADTs.ADTa(1), List(1.2, 2.1, 3.14), Some(None)),
-          """{"i":1,"s":"lol","t":[1.1,1.2],"a":{"i":1},"q":[1.2,2.1,3.14],"o":[[]]}"""
+          """{"i":1,"s":"lol","t":[1.1,1.2],"a":{"i":1},"q":[1.2,2.1,3.14],"o":[[]]}""",
+          upack.Obj(
+            upack.Str("i") -> upack.Int32(1),
+            upack.Str("s") -> upack.Str("lol"),
+            upack.Str("t") -> upack.Arr(upack.Float64(1.1), upack.Float64(1.2)),
+            upack.Str("a") -> upack.Obj(upack.Str("i") -> upack.Int32(1)),
+            upack.Str("q") -> upack.Arr(
+              upack.Float64(1.2),
+              upack.Float64(2.1),
+              upack.Float64(3.14)
+            ),
+            upack.Str("o") -> upack.Arr(upack.Arr())
+          )
         )
         val chunks = for (i <- 1 to 18) yield {
           val rhs = if (i % 2 == 1) "1" else "\"1\""
@@ -144,89 +185,330 @@ object MacroTests extends TestSuite {
         // written. This is feasible because sealed hierarchies can only have a
         // finite number of cases, so we can just check them all and decide which
         // class the instance belongs to.
+
+        // Make sure the tagged dictionary parser is able to parse cases where
+        // the $type-tag appears later in the dict. It does this by a totally
+        // different code-path than for tag-first dicts, using an intermediate
+        // AST, so make sure that code path works too.
         import Hierarchy._
         test("shallow"){
-          test - rw(B(1), """{"$type": "upickle.Hierarchy.B", "i":1}""")
-          test - rw(C("a", "b"), """{"$type": "upickle.Hierarchy.C", "s1":"a","s2":"b"}""")
-          test - rw(AnZ: Z, """ "upickle.Hierarchy.AnZ" """, """{"$type": "upickle.Hierarchy.AnZ"}""")
-          test - rw(AnZ, """ "upickle.Hierarchy.AnZ" """, """{"$type": "upickle.Hierarchy.AnZ"}""")
-          test - rw(Hierarchy.B(1): Hierarchy.A, """{"$type": "upickle.Hierarchy.B", "i":1}""")
-          test - rw(C("a", "b"): A, """{"$type": "upickle.Hierarchy.C", "s1":"a","s2":"b"}""")
-
-        }
-        test("tagLast"){
-          // Make sure the tagged dictionary parser is able to parse cases where
-          // the $type-tag appears later in the dict. It does this by a totally
-          // different code-path than for tag-first dicts, using an intermediate
-          // AST, so make sure that code path works too.
-          test - rw(
-            C("a", "b"),
-            """{"$type": "upickle.Hierarchy.C","s1":"a","s2":"b"}""",
-            """{"s1":"a","s2":"b", "$type": "upickle.Hierarchy.C"}"""
-          )
-
           test - rw(
             B(1),
             """{"$type": "upickle.Hierarchy.B", "i":1}""",
-            """{"i":1, "$type": "upickle.Hierarchy.B"}"""
+            """{"i":1, "$type": "upickle.Hierarchy.B"}""",
+            upack.Obj(
+              upack.Str("$type") -> upack.Str("upickle.Hierarchy.B"),
+              upack.Str("i") -> upack.Int32(1)
+            ),
+            upack.Obj(
+              upack.Str("i") -> upack.Int32(1),
+              upack.Str("$type") -> upack.Str("upickle.Hierarchy.B")
+            )
           )
-
+          test - rw(
+            C("a", "b"),
+            """{"$type": "upickle.Hierarchy.C", "s1":"a","s2":"b"}""",
+            """{"s1":"a","s2":"b", "$type": "upickle.Hierarchy.C"}""",
+            upack.Obj(
+              upack.Str("$type") -> upack.Str("upickle.Hierarchy.C"),
+              upack.Str("s1") -> upack.Str("a"),
+              upack.Str("s2") -> upack.Str("b")
+            ),
+            upack.Obj(
+              upack.Str("s1") -> upack.Str("a"),
+              upack.Str("s2") -> upack.Str("b"),
+              upack.Str("$type") -> upack.Str("upickle.Hierarchy.C")
+            )
+          )
+          test - rw(
+            AnZ: Z,
+            """ "upickle.Hierarchy.AnZ" """,
+            """{"$type": "upickle.Hierarchy.AnZ"}""",
+            upack.Str("upickle.Hierarchy.AnZ"),
+            upack.Obj(upack.Str("$type") -> upack.Str("upickle.Hierarchy.AnZ"))
+          )
+          test - rw(
+            AnZ,
+            """ "upickle.Hierarchy.AnZ" """,
+            """{"$type": "upickle.Hierarchy.AnZ"}""",
+            upack.Str("upickle.Hierarchy.AnZ"),
+            upack.Obj(upack.Str("$type") -> upack.Str("upickle.Hierarchy.AnZ"))
+          )
+          test - rw(
+            Hierarchy.B(1): Hierarchy.A,
+            """{"$type": "upickle.Hierarchy.B", "i":1}""",
+            """{"i":1, "$type": "upickle.Hierarchy.B"}""",
+            upack.Obj(
+              upack.Str("$type") -> upack.Str("upickle.Hierarchy.B"),
+              upack.Str("i") -> upack.Int32(1)
+            ),
+            upack.Obj(
+              upack.Str("i") -> upack.Int32(1),
+              upack.Str("$type") -> upack.Str("upickle.Hierarchy.B")
+            )
+          )
           test - rw(
             C("a", "b"): A,
-            """{"$type": "upickle.Hierarchy.C","s1":"a","s2":"b"}""",
-            """{"s1":"a","s2":"b", "$type": "upickle.Hierarchy.C"}"""
+            """{"$type": "upickle.Hierarchy.C", "s1":"a","s2":"b"}""",
+            """{"s1":"a","s2":"b", "$type": "upickle.Hierarchy.C"}""",
+            upack.Obj(
+              upack.Str("$type") -> upack.Str("upickle.Hierarchy.C"),
+              upack.Str("s1") -> upack.Str("a"),
+              upack.Str("s2") -> upack.Str("b")
+            ),
+            upack.Obj(
+              upack.Str("s1") -> upack.Str("a"),
+              upack.Str("s2") -> upack.Str("b"),
+              upack.Str("$type") -> upack.Str("upickle.Hierarchy.C")
+            )
           )
         }
+
         test("deep"){
           import DeepHierarchy._
 
-          test - rw(B(1), """{"$type": "upickle.DeepHierarchy.B", "i":1}""")
-          test - rw(B(1): A, """{"$type": "upickle.DeepHierarchy.B", "i":1}""")
-          test - rw(AnQ(1): Q, """{"$type": "upickle.DeepHierarchy.AnQ", "i":1}""")
-          test - rw(AnQ(1), """{"$type": "upickle.DeepHierarchy.AnQ","i":1}""")
+          test - rw(
+            B(1),
+            """{"$type": "upickle.DeepHierarchy.B", "i":1}""",
+            upack.Obj(
+              upack.Str("$type") -> upack.Str("upickle.DeepHierarchy.B"),
+              upack.Str("i") -> upack.Int32(1)
+            )
+          )
+          test - rw(
+            B(1): A,
+            """{"$type": "upickle.DeepHierarchy.B", "i":1}""",
+            upack.Obj(
+              upack.Str("$type") -> upack.Str("upickle.DeepHierarchy.B"),
+              upack.Str("i") -> upack.Int32(1)
+            )
+          )
+          test - rw(
+            AnQ(1): Q,
+            """{"$type": "upickle.DeepHierarchy.AnQ", "i":1}""",
+            upack.Obj(
+              upack.Str("$type") -> upack.Str("upickle.DeepHierarchy.AnQ"),
+              upack.Str("i") -> upack.Int32(1)
+            )
+          )
+          test - rw(
+            AnQ(1),
+            """{"$type": "upickle.DeepHierarchy.AnQ","i":1}""",
+            upack.Obj(
+              upack.Str("$type") -> upack.Str("upickle.DeepHierarchy.AnQ"),
+              upack.Str("i") -> upack.Int32(1)
+            )
+          )
 
-          test - rw(F(AnQ(1)), """{"$type": "upickle.DeepHierarchy.F","q":{"$type":"upickle.DeepHierarchy.AnQ", "i":1}}""")
-          test - rw(F(AnQ(2)): A, """{"$type": "upickle.DeepHierarchy.F","q":{"$type":"upickle.DeepHierarchy.AnQ", "i":2}}""")
-          test - rw(F(AnQ(3)): C, """{"$type": "upickle.DeepHierarchy.F","q":{"$type":"upickle.DeepHierarchy.AnQ", "i":3}}""")
-          test - rw(D("1"), """{"$type": "upickle.DeepHierarchy.D", "s":"1"}""")
-          test - rw(D("1"): C, """{"$type": "upickle.DeepHierarchy.D", "s":"1"}""")
-          test - rw(D("1"): A, """{"$type": "upickle.DeepHierarchy.D", "s":"1"}""")
-          test - rw(E(true), """{"$type": "upickle.DeepHierarchy.E", "b":true}""")
-          test - rw(E(true): C, """{"$type": "upickle.DeepHierarchy.E","b":true}""")
-          test - rw(E(true): A, """{"$type": "upickle.DeepHierarchy.E", "b":true}""")
+          test - rw(
+            F(AnQ(1)),
+            """{"$type": "upickle.DeepHierarchy.F","q":{"$type":"upickle.DeepHierarchy.AnQ", "i":1}}""",
+            upack.Obj(
+              upack.Str("$type") -> upack.Str("upickle.DeepHierarchy.F"),
+              upack.Str("q") -> upack.Obj(
+                upack.Str("$type") -> upack.Str("upickle.DeepHierarchy.AnQ"),
+                upack.Str("i") -> upack.Int32(1)
+              )
+            )
+          )
+          test - rw(
+            F(AnQ(2)): A,
+            """{"$type": "upickle.DeepHierarchy.F","q":{"$type":"upickle.DeepHierarchy.AnQ", "i":2}}""",
+            upack.Obj(
+              upack.Str("$type") -> upack.Str("upickle.DeepHierarchy.F"),
+              upack.Str("q") -> upack.Obj(
+                upack.Str("$type") -> upack.Str("upickle.DeepHierarchy.AnQ"),
+                upack.Str("i") -> upack.Int32(2)
+              )
+            )
+          )
+          test - rw(
+            F(AnQ(3)): C,
+            """{"$type": "upickle.DeepHierarchy.F","q":{"$type":"upickle.DeepHierarchy.AnQ", "i":3}}""",
+            upack.Obj(
+              upack.Str("$type") -> upack.Str("upickle.DeepHierarchy.F"),
+              upack.Str("q") -> upack.Obj(
+                upack.Str("$type") -> upack.Str("upickle.DeepHierarchy.AnQ"),
+                upack.Str("i") -> upack.Int32(3)
+              )
+            )
+          )
+          test - rw(
+            D("1"),
+            """{"$type": "upickle.DeepHierarchy.D", "s":"1"}""",
+            upack.Obj(
+              upack.Str("$type") -> upack.Str("upickle.DeepHierarchy.D"),
+              upack.Str("s") -> upack.Str("1")
+            )
+          )
+          test - rw(
+            D("1"): C,
+            """{"$type": "upickle.DeepHierarchy.D", "s":"1"}""",
+            upack.Obj(
+              upack.Str("$type") -> upack.Str("upickle.DeepHierarchy.D"),
+              upack.Str("s") -> upack.Str("1")
+            )
+          )
+          test - rw(
+            D("1"): A,
+            """{"$type": "upickle.DeepHierarchy.D", "s":"1"}""",
+            upack.Obj(
+              upack.Str("$type") -> upack.Str("upickle.DeepHierarchy.D"),
+              upack.Str("s") -> upack.Str("1")
+            )
+          )
+          test - rw(
+            E(true),
+            """{"$type": "upickle.DeepHierarchy.E", "b":true}""",
+            upack.Obj(
+              upack.Str("$type") -> upack.Str("upickle.DeepHierarchy.E"),
+              upack.Str("b") -> upack.True
+            )
+          )
+          test - rw(
+            E(true): C,
+            """{"$type": "upickle.DeepHierarchy.E","b":true}""",
+            upack.Obj(
+              upack.Str("$type") -> upack.Str("upickle.DeepHierarchy.E"),
+              upack.Str("b") -> upack.True
+            )
+          )
+          test - rw(
+            E(true): A,
+            """{"$type": "upickle.DeepHierarchy.E", "b":true}""",
+            upack.Obj(
+              upack.Str("$type") -> upack.Str("upickle.DeepHierarchy.E"),
+              upack.Str("b") -> upack.True
+            )
+          )
         }
       }
       test("singleton"){
         import Singletons._
 
-        rw(BB, """ "upickle.Singletons.BB" """, """{"$type":"upickle.Singletons.BB"}""")
-        rw(CC, """ "upickle.Singletons.CC" """, """{"$type":"upickle.Singletons.CC"}""")
-        rw(BB: AA, """ "upickle.Singletons.BB" """, """{"$type":"upickle.Singletons.BB"}""")
-        rw(CC: AA, """ "upickle.Singletons.CC" """, """{"$type":"upickle.Singletons.CC"}""")
+        rw(
+          BB,
+          """ "upickle.Singletons.BB" """,
+          """{"$type":"upickle.Singletons.BB"}""",
+          upack.Str("upickle.Singletons.BB"),
+          upack.Obj(upack.Str("$type") -> upack.Str("upickle.Singletons.BB"))
+        )
+        rw(
+          CC,
+          """ "upickle.Singletons.CC" """,
+          """{"$type":"upickle.Singletons.CC"}""",
+          upack.Str("upickle.Singletons.CC"),
+          upack.Obj(upack.Str("$type") -> upack.Str("upickle.Singletons.CC"))
+        )
+        rw(
+          BB: AA,
+          """ "upickle.Singletons.BB" """,
+          """{"$type":"upickle.Singletons.BB"}""",
+          upack.Str("upickle.Singletons.BB"),
+          upack.Obj(upack.Str("$type") -> upack.Str("upickle.Singletons.BB"))
+        )
+        rw(
+          CC: AA,
+          """ "upickle.Singletons.CC" """,
+          """{"$type":"upickle.Singletons.CC"}""",
+          upack.Str("upickle.Singletons.CC"),
+          upack.Obj(upack.Str("$type") -> upack.Str("upickle.Singletons.CC"))
+        )
       }
     }
     test("robustnessAgainstVaryingSchemas"){
       test("renameKeysViaAnnotations"){
         import Annotated._
 
-        test - rw(B(1), """{"$type": "0", "omg":1}""")
-        test - rw(C("a", "b"), """{"$type": "1", "lol":"a","wtf":"b"}""")
+        test - rw(
+          B(1),
+          """{"$type": "0", "omg":1}""",
+          upack.Obj(
+            upack.Str("$type") -> upack.Str("0"),
+            upack.Str("omg") -> upack.Int32(1)
+          )
+        )
+        test - rw(
+          C("a", "b"),
+          """{"$type": "1", "lol":"a","wtf":"b"}""",
+          upack.Obj(
+            upack.Str("$type") -> upack.Str("1"),
+            upack.Str("lol") -> upack.Str("a"),
+            upack.Str("wtf") -> upack.Str("b")
+          )
+        )
 
-        test - rw(B(1): A, """{"$type": "0", "omg":1}""")
-        test - rw(C("a", "b"): A, """{"$type": "1", "lol":"a","wtf":"b"}""")
+        test - rw(
+          B(1): A,
+          """{"$type": "0", "omg":1}""",
+          upack.Obj(
+            upack.Str("$type") -> upack.Str("0"),
+            upack.Str("omg") -> upack.Int32(1)
+          )
+        )
+        test - rw(
+          C("a", "b"): A,
+          """{"$type": "1", "lol":"a","wtf":"b"}""",
+          upack.Obj(
+            upack.Str("$type") -> upack.Str("1"),
+            upack.Str("lol") -> upack.Str("a"),
+            upack.Str("wtf") -> upack.Str("b")
+          )
+        )
       }
       test("useDefaults"){
         // Ignore the values which match the default when writing and
         // substitute in defaults when reading if the key is missing
         import Defaults._
-        test - rw(ADTa(), "{}")
-        test - rw(ADTa(321), """{"i":321}""")
-        test - rw(ADTb(s = "123"), """{"s":"123"}""")
-        test - rw(ADTb(i = 234, s = "567"), """{"i":234,"s":"567"}""")
-        test - rw(ADTc(s = "123"), """{"s":"123"}""")
-        test - rw(ADTc(i = 234, s = "567"), """{"i":234,"s":"567"}""")
-        test - rw(ADTc(t = (12.3, 45.6), s = "789"), """{"s":"789","t":[12.3,45.6]}""")
-        test - rw(ADTc(t = (12.3, 45.6), s = "789", i = 31337), """{"i":31337,"s":"789","t":[12.3,45.6]}""")
+        test - rw(ADTa(), "{}", upack.Obj())
+        test - rw(
+          ADTa(321),
+          """{"i":321}""",
+          upack.Obj(upack.Str("i") -> upack.Int32(321))
+        )
+        test - rw(
+          ADTb(s = "123"),
+          """{"s":"123"}""",
+          upack.Obj(upack.Str("s") -> upack.Str("123"))
+        )
+        test - rw(
+          ADTb(i = 234, s = "567"),
+          """{"i":234,"s":"567"}""",
+          upack.Obj(
+            upack.Str("i") -> upack.Int32(234),
+            upack.Str("s") -> upack.Str("567")
+          )
+        )
+        test - rw(
+          ADTc(s = "123"),
+          """{"s":"123"}""",
+          upack.Obj(upack.Str("s") -> upack.Str("123"))
+        )
+        test - rw(
+          ADTc(i = 234, s = "567"),
+          """{"i":234,"s":"567"}""",
+          upack.Obj(
+            upack.Str("i") -> upack.Int32(234),
+            upack.Str("s") -> upack.Str("567")
+          )
+        )
+        test - rw(
+          ADTc(t = (12.3, 45.6), s = "789"),
+          """{"s":"789","t":[12.3,45.6]}""",
+          upack.Obj(
+            upack.Str("s") -> upack.Str("789"),
+            upack.Str("t") -> upack.Arr(upack.Float64(12.3), upack.Float64(45.6))
+          )
+        )
+        test - rw(
+          ADTc(t = (12.3, 45.6), s = "789", i = 31337),
+          """{"i":31337,"s":"789","t":[12.3,45.6]}""",
+          upack.Obj(
+            upack.Str("i") -> upack.Int32(31337),
+            upack.Str("s") -> upack.Str("789"),
+            upack.Str("t") -> upack.Arr(upack.Float64(12.3), upack.Float64(45.6))
+          )
+        )
       }
       test("ignoreExtraFieldsWhenDeserializing"){
         import ADTs._
@@ -239,17 +521,28 @@ object MacroTests extends TestSuite {
 
     test("custom"){
       test("clsReaderWriter"){
-        rw(new Custom.Thing2(1, "s"), """ "1 s" """)
-        rw(new Custom.Thing2(10, "sss"), """ "10 sss" """)
+        rw(new Custom.Thing2(1, "s"), """ "1 s" """, upack.Str("1 s"))
+        rw(new Custom.Thing2(10, "sss"), """ "10 sss" """, upack.Str("10 sss"))
       }
       test("caseClsReaderWriter"){
-        rw(new Custom.Thing3(1, "s"), """ "1 s" """)
-        rw(new Custom.Thing3(10, "sss"), """ "10 sss" """)
+        rw(new Custom.Thing3(1, "s"), """ "1 s" """, upack.Str("1 s"))
+        rw(new Custom.Thing3(10, "sss"), """ "10 sss" """, upack.Str("10 sss"))
       }
     }
     test("varargs"){
-      rw(Varargs.Sentence("a", "b", "c"), """{"a":"a","bs":["b","c"]}""")
-      rw(Varargs.Sentence("a"), """{"a":"a","bs":[]}""")
+      rw(
+        Varargs.Sentence("a", "b", "c"),
+         """{"a":"a","bs":["b","c"]}""",
+        upack.Obj(
+          upack.Str("a") -> upack.Str("a"),
+          upack.Str("bs") -> upack.Arr(upack.Str("b"), upack.Str("c"))
+        )
+      )
+      rw(
+        Varargs.Sentence("a"),
+        """{"a":"a","bs":[]}""",
+        upack.Obj(upack.Str("a") -> upack.Str("a"), upack.Str("bs") -> upack.Arr())
+      )
     }
     test("defaultregression"){
       implicit val rw: upickle.default.ReadWriter[Trivial] = upickle.default.macroRW[Trivial]

--- a/upickle/test/src/upickle/PrimitiveTests.scala
+++ b/upickle/test/src/upickle/PrimitiveTests.scala
@@ -1,30 +1,30 @@
 package upickle
 import utest._
-import upickle.legacy.read
+import upickle.default.{read, write, readBinary, writeBinary, writeMsg, transform}
 import TestUtil._
 
 object PrimitiveTests extends TestSuite {
 
   def tests = Tests {
     test("Unit"){
-      rw((), "null", "{}")
+      rw((), "null", "{}", upack.Null, upack.Obj())
     }
     test("Boolean"){
-      test("true") - rw(true, "true", "\"true\"")
-      test("false") - rw(false, "false", "\"false\"")
-      test("null") - assert(read[Boolean]("null") == false)
+      test("true") - rw(true, "true", "\"true\"", upack.True, upack.Str("true"))
+      test("false") - rw(false, "false", "\"false\"", upack.False, upack.Str("false"))
+      test("null") - {
+        assert(read[Boolean]("null") == false)
+        assert(readBinary[Boolean](upack.Null) == false)
+      }
     }
     test("String"){
-      test("plain") - rw("i am a cow", """ "i am a cow" """)
-      test("quotes") - rw("i am a \"cow\"", """ "i am a \"cow\"" """)
+      test("plain") - rw("i am a cow", """ "i am a cow" """, upack.Str("i am a cow"))
+      test("quotes") - rw("i am a \"cow\"", """ "i am a \"cow\"" """, upack.Str("i am a \"cow\""))
       test("unicode"){
-        test - rw("叉烧包", "\"叉烧包\"")
-        test {upickle.default.write("叉烧包") ==> "\"叉烧包\""}
-        test {upickle.default.write("叉烧包", escapeUnicode = true) ==> "\"\\u53c9\\u70e7\\u5305\""}
-        test {upickle.default.read[String]("\"\\u53c9\\u70e7\\u5305\"") ==> "叉烧包"}
-        test {upickle.default.read[String]("\"叉烧包\"") ==> "叉烧包"}
+        test - rw("叉烧包", "\"叉烧包\"", upack.Str("叉烧包"))
+        test - rwEscape("叉烧包", "\"\\u53c9\\u70e7\\u5305\"")
       }
-      test("null") - rw(null: String, "null")
+      test("null") - rw(null: String, "null", upack.Null)
       test("chars"){
         for(i <- Char.MinValue until 55296/*Char.MaxValue*/) {
           rw(i.toString)
@@ -32,88 +32,209 @@ object PrimitiveTests extends TestSuite {
       }
     }
     test("Long"){
-      test("small") - rwNum(1: Long, "1", """ "1" """)
-      test("med") - rwNum(125123: Long, "125123", """ "125123" """)
-      test("minInt") - rwNum(Int.MinValue.toLong - 1, "-2147483649", """ "-2147483649" """)
-      test("maxInt") - rwNum(Int.MaxValue.toLong + 1, "2147483648", """ "2147483648" """)
-      test("min") - rwNum(Long.MinValue, """ "-9223372036854775808" """, "-9223372036854775808")
-      test("max") - rwNum(Long.MaxValue, """ "9223372036854775807" """, "9223372036854775807")
-      test("null") - assert(read[Long]("null") == 0)
-      test("invalid") - intercept[NumberFormatException](upickle.default.transform("a").to[Long])
+      test("small") - rwNum(1: Long, "1", """ "1" """, upack.Int64(1), upack.Str("1"))
+      test("med") - rwNum(
+        125123: Long,
+        "125123", """ "125123" """,
+        upack.Int64(125123), upack.Str("125123")
+      )
+      test("minInt") - rwNum(
+        Int.MinValue.toLong - 1,
+        "-2147483649", """ "-2147483649" """,
+        upack.Int64(-2147483649L), upack.Str("-2147483649")
+      )
+      test("maxInt") - rwNum(
+        Int.MaxValue.toLong + 1,
+        "2147483648", """ "2147483648" """,
+        upack.Int64(2147483648L), upack.Str("2147483648")
+      )
+      test("min") - rwNum(
+        Long.MinValue,
+        """ "-9223372036854775808" """, "-9223372036854775808",
+        upack.Int64(-9223372036854775808L), upack.Str("-9223372036854775808")
+      )
+      test("max") - rwNum(
+        Long.MaxValue,
+        """ "9223372036854775807" """, "9223372036854775807",
+        upack.Int64(9223372036854775807L), upack.Str("9223372036854775807")
+      )
+      test("null") - {
+        assert(read[Long]("null") == 0)
+        assert(readBinary[Long](upack.Null) == 0)
+      }
+      test("invalid") - intercept[NumberFormatException](transform("a").to[Long])
     }
     test("BigInt"){
-      test("whole") - rw(BigInt("125123"), """ "125123" """)
-      test("fractional") - rw(BigInt("1251231542312"), """ "1251231542312" """)
-      test("negative") - rw(BigInt("-1251231542312"), """ "-1251231542312" """)
+      test("whole") - rw(BigInt("125123"), """ "125123" """, upack.Str("125123"))
+      test("fractional") - rw(
+        BigInt("1251231542312"),
+        """ "1251231542312" """, upack.Str("1251231542312")
+      )
+      test("negative") - rw(
+        BigInt("-1251231542312"),
+        """ "-1251231542312" """, upack.Str("-1251231542312")
+      )
       test("big") - rw(
         BigInt("23420744098430230498023841234712512315423127402740234"),
-          """ "23420744098430230498023841234712512315423127402740234" """)
-      test("null") - rw(null: BigInt, "null")
+          """ "23420744098430230498023841234712512315423127402740234" """,
+        upack.Str("23420744098430230498023841234712512315423127402740234")
+      )
+      test("null") - rw(null: BigInt, "null", upack.Null)
     }
     test("BigDecimal"){
-      test("whole") - rw(BigDecimal("125123"), """ "125123" """)
-      test("fractional") - rw(BigDecimal("125123.1542312"), """ "125123.1542312" """)
-      test("negative") - rw(BigDecimal("-125123.1542312"), """ "-125123.1542312" """)
+      test("whole") - rw(BigDecimal("125123"), """ "125123" """, upack.Str("125123"))
+      test("fractional") - rw(
+        BigDecimal("125123.1542312"),
+        """ "125123.1542312" """, upack.Str("125123.1542312")
+      )
+      test("negative") - rw(
+        BigDecimal("-125123.1542312"),
+        """ "-125123.1542312" """, upack.Str("-125123.1542312")
+      )
       test("big") - rw(
         BigDecimal("234207440984302304980238412.15423127402740234"),
-          """ "234207440984302304980238412.15423127402740234" """)
-      test("null") - rw(null: BigDecimal, "null")
+        """ "234207440984302304980238412.15423127402740234" """,
+        upack.Str("234207440984302304980238412.15423127402740234")
+      )
+      test("null") - rw(null: BigDecimal, "null", upack.Null)
     }
 
     test("Int"){
-      test("small") - rwNum(1, "1", """ "1" """)
-      test("med") - rwNum(125123, "125123", """ "125123" """)
-      test("min") - rwNum(Int.MinValue, "-2147483648", """ "-2147483648" """)
-      test("null") - assert(read[Int]("null") == 0)
+      test("small") - rwNum(1, "1", """ "1" """, upack.Int32(1), upack.Str("1"))
+      test("med") - rwNum(
+        125123,
+        "125123", """ "125123" """,
+        upack.Int32(125123), upack.Str("125123")
+      )
+      test("min") - rwNum(
+        Int.MinValue,
+        "-2147483648", """ "-2147483648" """,
+        upack.Int32(-2147483648), upack.Str("-2147483648")
+      )
+      test("null") - {
+        assert(read[Int]("null") == 0)
+        assert(readBinary[Int](upack.Null) == 0)
+      }
     }
 
     test("Double"){
-      test("whole") - rwNum(125123: Double, """125123""", """125123.0""")
-      test("wholeLarge") - rwNum(1475741505173L: Double, """1475741505173""", """1475741505173.0""")
-      test("fractional") - rwNum(125123.1542312, """125123.1542312""", """ "125123.1542312" """)
-      test("negative") - rwNum(-125123.1542312, """-125123.1542312""", """ "-125123.1542312" """)
-      test("null") - assert(read[Double]("null") == 0.0)
-      test("nan") - assert(
-        java.lang.Double.isNaN(read[Double](""" "NaN" """)),
-        upickle.default.write(Double.NaN) == "\"NaN\""
+      test("whole") - rwNum(
+        125123: Double,
+        """125123""", """125123.0""",
+        upack.Float64(125123), upack.Str("125123.0")
       )
+      test("wholeLarge") - rwNum(
+        1475741505173L: Double,
+        """1475741505173""", """1475741505173.0""",
+        upack.Float64(1475741505173.0), upack.Str("1475741505173.0")
+      )
+      test("fractional") - rwNum(
+        125123.1542312,
+         """125123.1542312""", """ "125123.1542312" """,
+        upack.Float64(125123.1542312), upack.Str("125123.1542312")
+      )
+      test("negative") - rwNum(
+        -125123.1542312,
+        """-125123.1542312""", """ "-125123.1542312" """,
+        upack.Float64(-125123.1542312), upack.Str("-125123.1542312")
+      )
+      test("null") - {
+        assert(read[Double]("null") == 0.0)
+        assert(readBinary[Double](upack.Null) == 0.0)
+      }
+      test("nan") - {
+        assert(
+          java.lang.Double.isNaN(read[Double](""" "NaN" """)),
+          write(Double.NaN) == "\"NaN\""
+        )
+        assert(java.lang.Double.isNaN(readBinary[Double](upack.Float64(Double.NaN))))
+        val written = writeMsg(Double.NaN)
+        assert(java.lang.Double.isNaN(written.asInstanceOf[upack.Float64].value))
+      }
     }
 
     test("Short"){
-      test("simple") - rwNum(25123: Short, "25123", """ "25123" """)
-      test("min") - rwNum(Short.MinValue, "-32768", """ "-32768" """)
-      test("max") - rwNum(Short.MaxValue, "32767", """ "32767" """)
-      test("null") - assert(read[Short]("null") == 0)
+      test("simple") - rwNum(
+        25123: Short,
+        "25123", """ "25123" """,
+        upack.Int32(25123), upack.Str("25123")
+      )
+      test("min") - rwNum(
+        Short.MinValue,
+        "-32768", """ "-32768" """,
+        upack.Int32(-32768), upack.Str("-32768")
+      )
+      test("max") - rwNum(
+        Short.MaxValue,
+        "32767", """ "32767" """,
+        upack.Int32(32767), upack.Str("32767")
+      )
+      test("null") - {
+        assert(read[Short]("null") == 0)
+        assert(readBinary[Short](upack.Null) == 0)
+      }
       test("all"){
         for (i <- Short.MinValue to Short.MaxValue) rwNum(i)
       }
     }
 
     test("Byte"){
-      test("simple") - rwNum(125: Byte, "125", """ "125" """)
-      test("min") - rwNum(Byte.MinValue, "-128", """ "-128" """)
-      test("max") - rwNum(Byte.MaxValue, "127", """ "127" """)
-      test("null") - assert(read[Byte]("null") == 0)
+      test("simple") - rwNum(
+        125: Byte,
+        "125", """ "125" """,
+        upack.Int32(125), upack.Str("125")
+      )
+      test("min") - rwNum(
+        Byte.MinValue,
+        "-128", """ "-128" """,
+        upack.Int32(-128), upack.Str("-128")
+      )
+      test("max") - rwNum(
+        Byte.MaxValue,
+        "127", """ "127" """,
+        upack.Int32(127), upack.Str("127")
+      )
+      test("null") - {
+        assert(read[Byte]("null") == 0)
+        assert(readBinary[Byte](upack.Null) == 0)
+      }
       test("all"){
         for (i <- Byte.MinValue to Byte.MaxValue) rwNum(i)
       }
     }
 
     test("Float"){
-      test("simple") - rwNum(125.125f, """125.125""", """ "125.125" """)
+      test("simple") - rwNum(
+        125.125f,
+        """125.125""", """ "125.125" """,
+        upack.Float32(125.125f), upack.Str("125.125")
+      )
       test("min") - rwNum(Float.MinValue)
       test("minPos") - rwNum(Float.MinPositiveValue)
-      test("neg-inf") - rwNum(Float.NegativeInfinity, """ "-Infinity" """)
-      test("null") - assert(read[Float]("null") == 0.0)
-      test("nan") - assert(
-        java.lang.Float.isNaN(read[Float](""" "NaN" """)),
-        upickle.default.write(Float.NaN) == "\"NaN\""
+      test("neg-inf") - rwNum(
+        Float.NegativeInfinity,
+        """ "-Infinity" """,
+        upack.Float32(Float.NegativeInfinity)
       )
+      test("null") - {
+        assert(read[Float]("null") == 0.0f)
+        assert(readBinary[Float](upack.Null) == 0.0f)
+      }
+      test("nan") - {
+        assert(
+          java.lang.Float.isNaN(read[Float](""" "NaN" """)),
+          write(Float.NaN) == "\"NaN\""
+        )
+
+        assert(java.lang.Float.isNaN(readBinary[Float](upack.Float32(Float.NaN))))
+        val written = writeMsg(Float.NaN)
+        assert(java.lang.Float.isNaN(written.asInstanceOf[upack.Float32].value))
+      }
     }
 
     test("Char"){
-      test("f") - rwNoBinaryJson('f', """ "f" """)
-      test("plus") - rwNoBinaryJson('+', """ "+" """)
+      test("f") - rwNoBinaryJson('f', """ "f" """, upack.Int32('f'))
+      test("plus") - rwNoBinaryJson('+', """ "+" """, upack.Int32('+'))
 
       test("all"){
         for(i <- Char.MinValue until 55296/*Char.MaxValue*/) {

--- a/upickle/test/src/upickle/StructTests.scala
+++ b/upickle/test/src/upickle/StructTests.scala
@@ -15,51 +15,142 @@ object StructTests extends TestSuite {
 
   val tests = Tests {
     test("arrays"){
-      test("empty") - rwk(Array[Int](), "[]")(_.toSeq)
-      test("Boolean") - rwk(Array(true, false), "[true,false]")(_.toSeq)
-      test("Int") - rwk(Array(1, 2, 3, 4, 5), "[1,2,3,4,5]")(_.toSeq)
-      test("String") - rwk(Array("omg", "i am", "cow"), """["omg","i am","cow"]""")(_.toSeq)
-      test("Nulls") - rwk(Array(null, "i am", null), """[null,"i am",null]""")(_.toSeq)
+      test("empty") - rwk(Array[Int](), "[]", upack.Arr())(_.toSeq)
+      test("Boolean") - rwk(
+        Array(true, false),
+        "[true,false]",
+        upack.Arr(upack.True, upack.False)
+      )(_.toSeq)
+      test("Int") - rwk(
+        Array(1, 2, 3, 4, 5),
+        "[1,2,3,4,5]",
+        upack.Arr(upack.Int32(1), upack.Int32(2), upack.Int32(3), upack.Int32(4), upack.Int32(5))
+      )(_.toSeq)
+      test("String") - rwk(
+        Array("omg", "i am", "cow"),
+        """["omg","i am","cow"]""",
+        upack.Arr(upack.Str("omg"), upack.Str("i am"), upack.Str("cow"))
+      )(_.toSeq)
+      test("Nulls") - rwk(
+        Array(null, "i am", null),
+         """[null,"i am",null]""",
+        upack.Arr(upack.Null, upack.Str("i am"), upack.Null)
+      )(_.toSeq)
 
     }
 
     test("tuples"){
-      test("null") - rw(null: Tuple2[Int, Int], "null")
-      test("2") - rw((1, 2, 3.0), "[1,2,3]", "[1,2,3.0]")
-      test("2-1") - rw((false, 1), "[false,1]")
-      test("3") - rw(("omg", 1, "bbq"), """["omg",1,"bbq"]""")
+      test("null") - rw(null: Tuple2[Int, Int], "null", upack.Null)
+      test("2") - rw(
+        (1, 2, 3.0),
+        "[1,2,3]", "[1,2,3.0]",
+        upack.Arr(upack.Int32(1), upack.Int32(2), upack.Float64(3.0))
+      )
+      test("2-1") - rw((false, 1), "[false,1]", upack.Arr(upack.False, upack.Int32(1)))
+      test("3") - rw(
+        ("omg", 1, "bbq"),
+        """["omg",1,"bbq"]""",
+        upack.Arr(upack.Str("omg"), upack.Int32(1), upack.Str("bbq"))
+      )
       test("21") - rw(
         (1, 2.2, 3, 4, "5", 6, '7', 8, 9, 10.1, 11, 12, 13, 14.5, 15, "16", 17, 18, 19, 20, 21),
-        """[1,2.2,3,4,"5",6,"7",8,9,10.1,11,12,13,14.5,15,"16",17,18,19,20,21]"""
+        """[1,2.2,3,4,"5",6,"7",8,9,10.1,11,12,13,14.5,15,"16",17,18,19,20,21]""",
+        upack.Arr(
+          upack.Int32(1),
+          upack.Float64(2.2),
+          upack.Int32(3),
+          upack.Int32(4),
+          upack.Str("5"),
+          upack.Int32(6),
+          upack.Int32('7'),
+          upack.Int32(8),
+          upack.Int32(9),
+          upack.Float64(10.1),
+          upack.Int32(11),
+          upack.Int32(12),
+          upack.Int32(13),
+          upack.Float64(14.5),
+          upack.Int32(15),
+          upack.Str("16"),
+          upack.Int32(17),
+          upack.Int32(18),
+          upack.Int32(19),
+          upack.Int32(20),
+          upack.Int32(21)
+        )
       )
     }
 
     test("seqs"){
       test("Seq"){
-        rw(Seq(true, false), "[true,false]")
-        rw(Seq(): Seq[Int], "[]")
+        rw(Seq(true, false), "[true,false]", upack.Arr(upack.True, upack.False))
+        rw(Seq(): Seq[Int], "[]", upack.Arr())
       }
       test("Vector"){
-        rw(Vector(1, 2, 3, 4, 5), "[1,2,3,4,5]")
-        rw(Vector.empty[Int], "[]")
+        rw(
+          Vector(1, 2, 3, 4, 5),
+          "[1,2,3,4,5]",
+          upack.Arr(upack.Int32(1), upack.Int32(2), upack.Int32(3), upack.Int32(4), upack.Int32(5))
+        )
+        rw(Vector.empty[Int], "[]", upack.Arr())
       }
       test("List"){
-        rw(List("omg", "i am", "cow"), """["omg","i am","cow"]""")
-        rw(List(): List[String], "[]")
-        rw(Nil: List[List[Int]], "[]")
+        rw(
+          List("omg", "i am", "cow"),
+           """["omg","i am","cow"]""",
+          upack.Arr(upack.Str("omg"), upack.Str("i am"), upack.Str("cow"))
+        )
+        rw(List(): List[String], "[]", upack.Arr())
+        rw(Nil: List[List[Int]], "[]", upack.Arr())
       }
-      test("Set") - rw(Set("omg", "i am", "cow"), """["omg","i am","cow"]""")
-      test("SortedSet") - rw(collection.SortedSet("omg", "i am", "cow"), """["cow","i am","omg"]""")
+      test("Set") - rw(
+        Set("omg", "i am", "cow"),
+         """["omg","i am","cow"]""",
+        upack.Arr(upack.Str("omg"), upack.Str("i am"), upack.Str("cow"))
+      )
+      test("SortedSet") - rw(
+        collection.SortedSet("omg", "i am", "cow"),
+         """["cow","i am","omg"]""",
+        upack.Arr(upack.Str("cow"), upack.Str("i am"), upack.Str("omg"))
+      )
       test("immutable"){
-        test("Set") - rw(collection.immutable.Set("omg", "i am", "cow"), """["omg","i am","cow"]""")
-        test("Seq") - rw(collection.immutable.Seq("omg", "i am", "cow"), """["omg","i am","cow"]""")
-        test("List") - rw(collection.immutable.List("omg", "i am", "cow"), """["omg","i am","cow"]""")
-        test("Queue") - rw(collection.immutable.Queue("omg", "i am", "cow"), """["omg","i am","cow"]""")
+        test("Set") - rw(
+          collection.immutable.Set("omg", "i am", "cow"),
+           """["omg","i am","cow"]""",
+          upack.Arr(upack.Str("omg"), upack.Str("i am"), upack.Str("cow"))
+        )
+        test("Seq") - rw(
+          collection.immutable.Seq("omg", "i am", "cow"),
+          """["omg","i am","cow"]""",
+          upack.Arr(upack.Str("omg"), upack.Str("i am"), upack.Str("cow"))
+        )
+        test("List") - rw(
+          collection.immutable.List("omg", "i am", "cow"),
+           """["omg","i am","cow"]""",
+          upack.Arr(upack.Str("omg"), upack.Str("i am"), upack.Str("cow"))
+        )
+        test("Queue") - rw(
+          collection.immutable.Queue("omg", "i am", "cow"),
+          """["omg","i am","cow"]""",
+          upack.Arr(upack.Str("omg"), upack.Str("i am"), upack.Str("cow"))
+        )
       }
       test("mutable"){
-        test("Seq") - rw(collection.mutable.Seq("omg", "i am", "cow"), """["omg","i am","cow"]""")
-        test("Buffer") - rw(collection.mutable.Buffer("omg", "i am", "cow"), """["omg","i am","cow"]""")
-        test("SortedSet") - rw(collection.mutable.SortedSet("omg", "i am", "cow"), """["cow","i am","omg"]""")
+        test("Seq") - rw(
+          collection.mutable.Seq("omg", "i am", "cow"),
+           """["omg","i am","cow"]""",
+          upack.Arr(upack.Str("omg"), upack.Str("i am"), upack.Str("cow"))
+        )
+        test("Buffer") - rw(
+          collection.mutable.Buffer("omg", "i am", "cow"),
+          """["omg","i am","cow"]""",
+          upack.Arr(upack.Str("omg"), upack.Str("i am"), upack.Str("cow"))
+        )
+        test("SortedSet") - rw(
+          collection.mutable.SortedSet("omg", "i am", "cow"),
+          """["cow","i am","omg"]""",
+          upack.Arr(upack.Str("cow"), upack.Str("i am"), upack.Str("omg"))
+        )
       }
     }
 
@@ -67,46 +158,119 @@ object StructTests extends TestSuite {
       test("structured") {
         test("Structured") - rw[Map[List[Int], List[Int]]](
           Map(Nil -> List(1), List(1) -> List(1, 2, 3)),
-          "[[[],[1]],[[1],[1,2,3]]]"
+          "[[[],[1]],[[1],[1,2,3]]]",
+          upack.Obj(
+            upack.Arr() -> upack.Arr(upack.Int32(1)),
+            upack.Arr(upack.Int32(1)) -> upack.Arr(upack.Int32(1), upack.Int32(2), upack.Int32(3))
+          ),
+          upack.Arr(
+            upack.Arr(upack.Arr(), upack.Arr(upack.Int32(1))),
+            upack.Arr(upack.Arr(upack.Int32(1)), upack.Arr(upack.Int32(1), upack.Int32(2), upack.Int32(3)))
+          )
         )
         test("Structured2") - rw[collection.mutable.Map[List[Int], List[Int]]](
           collection.mutable.Map(Nil -> List(1), List(1) -> List(1, 2, 3)),
           "[[[1],[1,2,3]], [[],[1]]]",
-          "[[[],[1]],[[1],[1,2,3]]]"
+          "[[[],[1]],[[1],[1,2,3]]]",
+          upack.Obj(
+            upack.Arr() -> upack.Arr(upack.Int32(1)),
+            upack.Arr(upack.Int32(1)) -> upack.Arr(upack.Int32(1), upack.Int32(2), upack.Int32(3))
+          ),
+          upack.Arr(
+            upack.Arr(upack.Arr(), upack.Arr(upack.Int32(1))),
+            upack.Arr(upack.Arr(upack.Int32(1)), upack.Arr(upack.Int32(1), upack.Int32(2), upack.Int32(3)))
+          )
         )
         test("Structured3") - rw[collection.immutable.Map[List[Int], List[Int]]](
           collection.immutable.Map(Nil -> List(1), List(1) -> List(1, 2, 3)),
-          "[[[],[1]],[[1],[1,2,3]]]"
+          "[[[],[1]],[[1],[1,2,3]]]",
+          upack.Obj(
+            upack.Arr() -> upack.Arr(upack.Int32(1)),
+            upack.Arr(upack.Int32(1)) -> upack.Arr(upack.Int32(1), upack.Int32(2), upack.Int32(3))
+          ),
+          upack.Arr(
+            upack.Arr(upack.Arr(), upack.Arr(upack.Int32(1))),
+            upack.Arr(upack.Arr(upack.Int32(1)), upack.Arr(upack.Int32(1), upack.Int32(2), upack.Int32(3)))
+          )
         )
         test("Structured4") - rw[collection.Map[List[Int], List[Int]]](
           collection.Map(Nil -> List(1), List(1) -> List(1, 2, 3)),
-          "[[[],[1]],[[1],[1,2,3]]]"
+          "[[[],[1]],[[1],[1,2,3]]]",
+          upack.Obj(
+            upack.Arr() -> upack.Arr(upack.Int32(1)),
+            upack.Arr(upack.Int32(1)) -> upack.Arr(upack.Int32(1), upack.Int32(2), upack.Int32(3))
+          ),
+          upack.Arr(
+            upack.Arr(upack.Arr(), upack.Arr(upack.Int32(1))),
+            upack.Arr(upack.Arr(upack.Int32(1)), upack.Arr(upack.Int32(1), upack.Int32(2), upack.Int32(3)))
+          )
         )
         test("StructuredEmpty") - rw[Map[List[Int], List[Int]]](
           Map[List[Int], List[Int]](),
-          "[]"
+          "[]",
+          upack.Obj(),
+          upack.Arr()
         )
       }
       test("string"){
         test("String") - rw(
           Map("Hello" -> List(1), "World" -> List(1, 2, 3)),
-          """{"Hello":[1],"World":[1,2,3]}"""
+          """{"Hello":[1],"World":[1,2,3]}""",
+          """[["Hello",[1]],["World",[1,2,3]]]""",
+          upack.Obj(
+            upack.Str("Hello") -> upack.Arr(upack.Int32(1)),
+            upack.Str("World") -> upack.Arr(upack.Int32(1), upack.Int32(2), upack.Int32(3))
+          ),
+          upack.Arr(
+            upack.Arr(upack.Str("Hello"), upack.Arr(upack.Int32(1))),
+            upack.Arr(upack.Str("World"), upack.Arr(upack.Int32(1), upack.Int32(2), upack.Int32(3)))
+          )
         )
         test("String2") - rw(
           collection.Map("Hello" -> List(1), "World" -> List(1, 2, 3)),
-          """{"Hello":[1],"World":[1,2,3]}"""
+          """{"Hello":[1],"World":[1,2,3]}""",
+          """[["Hello",[1]],["World",[1,2,3]]]""",
+          upack.Obj(
+            upack.Str("Hello") -> upack.Arr(upack.Int32(1)),
+            upack.Str("World") -> upack.Arr(upack.Int32(1), upack.Int32(2), upack.Int32(3))
+          ),
+          upack.Arr(
+            upack.Arr(upack.Str("Hello"), upack.Arr(upack.Int32(1))),
+            upack.Arr(upack.Str("World"), upack.Arr(upack.Int32(1), upack.Int32(2), upack.Int32(3)))
+          )
         )
         test("String3") - rw(
           collection.immutable.Map("Hello" -> List(1), "World" -> List(1, 2, 3)),
-          """{"Hello":[1],"World":[1,2,3]}"""
+          """{"Hello":[1],"World":[1,2,3]}""",
+          """[["Hello",[1]],["World",[1,2,3]]]""",
+          upack.Obj(
+            upack.Str("Hello") -> upack.Arr(upack.Int32(1)),
+            upack.Str("World") -> upack.Arr(upack.Int32(1), upack.Int32(2), upack.Int32(3))
+          ),
+          upack.Arr(
+            upack.Arr(upack.Str("Hello"), upack.Arr(upack.Int32(1))),
+            upack.Arr(upack.Str("World"), upack.Arr(upack.Int32(1), upack.Int32(2), upack.Int32(3)))
+          )
         )
         test("String4") - rw[collection.mutable.Map[String, List[Int]]](
           collection.mutable.Map("Hello" -> List(1), "World" -> List(1, 2, 3)),
-          """{"Hello":[1],"World":[1,2,3]}"""
+          """{"Hello":[1],"World":[1,2,3]}""",
+          """[["Hello",[1]],["World",[1,2,3]]]""",
+          upack.Obj(
+            upack.Str("Hello") -> upack.Arr(upack.Int32(1)),
+            upack.Str("World") -> upack.Arr(upack.Int32(1), upack.Int32(2), upack.Int32(3))
+          ),
+          upack.Arr(
+            upack.Arr(upack.Str("Hello"), upack.Arr(upack.Int32(1))),
+            upack.Arr(upack.Str("World"), upack.Arr(upack.Int32(1), upack.Int32(2), upack.Int32(3)))
+          )
         )
         test("StringEmpty") - rw(
           Map[String, List[Int]](),
-          "{}"
+          "{}",
+          "[]",
+          upack.Obj(),
+          upack.Arr()
         )
       }
       test("primitive"){
@@ -121,25 +285,76 @@ object StructTests extends TestSuite {
           Map(true -> false, false -> true),
           """{"true": false, "false": true}""",
           """[[true, false], [false, true]]""",
-          """[["true", false], ["false", true]]"""
+          """[["true", false], ["false", true]]""",
+          upack.Obj(upack.True -> upack.False, upack.False -> upack.True),
+          upack.Arr(upack.Arr(upack.True, upack.False), upack.Arr(upack.False, upack.True)),
+          upack.Arr(
+            upack.Arr(upack.Str("true"), upack.False),
+            upack.Arr(upack.Str("false"), upack.True)
+          )
         )
         test("int") - rw(
           Map(1 -> 2, 3 -> 4, 5 -> 6),
           """{"1": 2, "3": 4, "5": 6}""",
           """[[1, 2], [3, 4], [5, 6]]""",
-          """[["1", 2], ["3", 4], ["5", 6]]"""
+          """[["1", 2], ["3", 4], ["5", 6]]""",
+          upack.Obj(
+            upack.Int32(1) -> upack.Int32(2),
+            upack.Int32(3) -> upack.Int32(4),
+            upack.Int32(5) -> upack.Int32(6)
+          ),
+          upack.Arr(
+            upack.Arr(upack.Int32(1), upack.Int32(2)),
+            upack.Arr(upack.Int32(3), upack.Int32(4)),
+            upack.Arr(upack.Int32(5), upack.Int32(6))
+          ),
+          upack.Arr(
+            upack.Arr(upack.Str("1"), upack.Int32(2)),
+            upack.Arr(upack.Str("3"), upack.Int32(4)),
+            upack.Arr(upack.Str("5"), upack.Int32(6))
+          )
         )
         test("long") - rw(
           Map(1L -> 2L, 3L -> 4L, 5L -> 6L),
           """{"1": 2, "3": 4, "5": 6}""",
           """[[1, 2], [3, 4], [5, 6]]""",
-          """[["1", 2], ["3", 4], ["5", 6]]"""
+          """[["1", 2], ["3", 4], ["5", 6]]""",
+          upack.Obj(
+            upack.Int64(1) -> upack.Int64(2),
+            upack.Int64(3) -> upack.Int64(4),
+            upack.Int64(5) -> upack.Int64(6)
+          ),
+          upack.Arr(
+            upack.Arr(upack.Int64(1), upack.Int64(2)),
+            upack.Arr(upack.Int64(3), upack.Int64(4)),
+            upack.Arr(upack.Int64(5), upack.Int64(6))
+          ),
+          upack.Arr(
+            upack.Arr(upack.Str("1"), upack.Int64(2)),
+            upack.Arr(upack.Str("3"), upack.Int64(4)),
+            upack.Arr(upack.Str("5"), upack.Int64(6))
+          )
         )
 
         test("char") - rw(
           Map('a' -> 'b', 'c' -> 'd', 'e' -> 'f'),
           """{"a": "b", "c": "d", "e": "f"}""",
-          """[["a", "b"], ["c", "d"], ["e", "f"]]"""
+          """[["a", "b"], ["c", "d"], ["e", "f"]]""",
+          upack.Obj(
+            upack.Int32('a') -> upack.Int32('b'),
+            upack.Int32('c') -> upack.Int32('d'),
+            upack.Int32('e') -> upack.Int32('f')
+          ),
+          upack.Arr(
+            upack.Arr(upack.Int32('a'), upack.Int32('b')),
+            upack.Arr(upack.Int32('c'), upack.Int32('d')),
+            upack.Arr(upack.Int32('e'), upack.Int32('f'))
+          ),
+          upack.Arr(
+            upack.Arr(upack.Str("a"), upack.Int32('b')),
+            upack.Arr(upack.Str("c"), upack.Int32('d')),
+            upack.Arr(upack.Str("e"), upack.Int32('f'))
+          )
         )
 
         test("uuid") - rw(
@@ -148,57 +363,128 @@ object StructTests extends TestSuite {
             new java.util.UUID(987654321L, 123456789L)
           ),
           """{"00000000-075b-cd15-0000-00003ade68b1": "00000000-3ade-68b1-0000-0000075bcd15"}""",
-          """[["00000000-075b-cd15-0000-00003ade68b1", "00000000-3ade-68b1-0000-0000075bcd15"]]"""
+          """[["00000000-075b-cd15-0000-00003ade68b1", "00000000-3ade-68b1-0000-0000075bcd15"]]""",
+          upack.Obj(
+            upack.Str("00000000-075b-cd15-0000-00003ade68b1") ->
+            upack.Str("00000000-3ade-68b1-0000-0000075bcd15")
+          ),
+          upack.Arr(
+            upack.Arr(
+              upack.Str("00000000-075b-cd15-0000-00003ade68b1"),
+              upack.Str("00000000-3ade-68b1-0000-0000075bcd15")
+            )
+          )
         )
 
         test("symbol") - rw(
           Map(Symbol("abc") -> Symbol("def")),
           """{"abc": "def"}""",
-          """[["abc", "def"]]"""
+          """[["abc", "def"]]""",
+          upack.Obj(upack.Str("abc") -> upack.Str("def")),
+          upack.Arr(upack.Arr(upack.Str("abc"), upack.Str("def")))
         )
       }
     }
 
     test("option"){
-      test("Some") - rw(Some(123), "[123]")
-      test("None") - rw(None, "[]")
+      test("Some") - rw(Some(123), "[123]", upack.Arr(upack.Int32(123)))
+      test("None") - rw(None, "[]", upack.Arr())
       test("Option"){
-        rw(Some(123): Option[Int], "[123]")
-        rw(None: Option[Int], "[]")
+        rw(Some(123): Option[Int], "[123]", upack.Arr(upack.Int32(123)))
+        rw(None: Option[Int], "[]", upack.Arr())
       }
     }
 
     test("either"){
-      test("Left") - rw(Left(123): Left[Int, Int], """[0,123]""")
-      test("Right") - rw(Right(123): Right[Int, Int], """[1,123]""")
+      test("Left") - rw(
+        Left(123): Left[Int, Int],
+        """[0,123]""",
+        upack.Arr(upack.Float64(0), upack.Int32(123))
+      )
+      test("Right") - rw(
+        Right(123): Right[Int, Int],
+        """[1,123]""",
+        upack.Arr(upack.Float64(1), upack.Int32(123))
+      )
       test("Either"){
-        rw(Left(123): Either[Int, Int], """[0,123]""")
-        rw(Right(123): Either[Int, Int], """[1,123]""")
+        rw(
+          Left(123): Either[Int, Int],
+          """[0,123]""",
+          upack.Arr(upack.Float64(0), upack.Int32(123))
+        )
+        rw(
+          Right(123): Either[Int, Int],
+          """[1,123]""",
+          upack.Arr(upack.Float64(1), upack.Int32(123))
+        )
       }
     }
 
     test("combinations"){
       test("SeqListMapOptionString") - rw[Seq[List[Map[Option[String], String]]]](
         Seq(Nil, List(Map(Some("omg") -> "omg"), Map(Some("lol") -> "lol", None -> "")), List(Map())),
-        """[[],[[[["omg"],"omg"]],[[["lol"],"lol"],[[],""]]],[[]]]"""
+        """[[],[[[["omg"],"omg"]],[[["lol"],"lol"],[[],""]]],[[]]]""",
+        upack.Arr(
+          upack.Arr(),
+          upack.Arr(
+            upack.Obj(upack.Arr(upack.Str("omg")) -> upack.Str("omg")),
+            upack.Obj(
+              upack.Arr(upack.Str("lol")) -> upack.Str("lol"),
+              upack.Arr() -> upack.Str("")
+            )
+          ),
+          upack.Arr(upack.Obj())
+        )
       )
 
       test("NullySeqListMapOptionString") - rw[Seq[List[Map[Option[String], String]]]](
         Seq(Nil, List(Map(Some(null) -> "omg"), Map(Some("lol") -> null, None -> "")), List(null)),
-        """[[],[[[[null],"omg"]],[[["lol"],null],[[],""]]],[null]]"""
+        """[[],[[[[null],"omg"]],[[["lol"],null],[[],""]]],[null]]""",
+        upack.Arr(
+          upack.Arr(),
+          upack.Arr(
+            upack.Obj(upack.Arr(upack.Null) -> upack.Str("omg")),
+            upack.Obj(
+              upack.Arr(upack.Str("lol")) -> upack.Null,
+              upack.Arr() -> upack.Str("")
+            )
+          ),
+          upack.Arr(upack.Null)
+        )
       )
 
       test("tuples") - rw(
         (1, (2.0, true), (3.0, 4.0, 5.0)),
         """[1,[2,true],[3,4,5]]""",
-        """[1,[2.0,true],[3.0,4.0,5.0]]"""
+        """[1,[2.0,true],[3.0,4.0,5.0]]""",
+        upack.Arr(
+          upack.Int32(1),
+          upack.Arr(upack.Float64(2.0), upack.True),
+          upack.Arr(upack.Float64(3.0), upack.Float64(4.0), upack.Float64(5.0))
+        )
       )
 
       test("EitherDurationOptionDuration"){
-        rw(Left(10 seconds): Either[Duration, Int], """[0,"10000000000"]""")
-        rw(Right(Some(0.33 millis)): Either[Int, Option[Duration]], """[1,["330000"]]""")
-        rw(Left(10 seconds): Either[Duration, Option[Duration]], """[0,"10000000000"]""")
-        rw(Right(Some(0.33 millis)): Either[Duration, Option[Duration]], """[1,["330000"]]""")
+        rw(
+          Left(10 seconds): Either[Duration, Int],
+          """[0,"10000000000"]""",
+          upack.Arr(upack.Float64(0.0), upack.Str("10000000000"))
+        )
+        rw(
+          Right(Some(0.33 millis)): Either[Int, Option[Duration]],
+          """[1,["330000"]]""",
+          upack.Arr(upack.Float64(1.0), upack.Arr(upack.Str("330000")))
+        )
+        rw(
+          Left(10 seconds): Either[Duration, Option[Duration]],
+          """[0,"10000000000"]""",
+          upack.Arr(upack.Float64(0.0), upack.Str("10000000000"))
+        )
+        rw(
+          Right(Some(0.33 millis)): Either[Duration, Option[Duration]],
+          """[1,["330000"]]""",
+          upack.Arr(upack.Float64(1.0), upack.Arr(upack.Str("330000")))
+        )
       }
     }
 


### PR DESCRIPTION
This PR augments the `rw` test helpers to also allow assertion of the `upack.Msg` version of the serialized values, and then goes through and adds them to all the existing tests.

Previously we were only asserting that values could be round-tripped, without checking what they serialized into.

Now, the message-pack format tests are brought up to par with the JSON format: we ensure that the message-pack output is something reasonable, explicitly specify the output that each value `t` is supposed to serialize to, as well as listing out what other inputs we expect to be able to read into `t` apart from the one that it is written out to (e.g. old formats for backwards-compatibility)