### PR TITLE
Add Scala.js source map compiler flag

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -130,6 +130,7 @@ trait CommonJsModule extends CommonPublishModule with ScalaJSModule{
   def crossScalaJSVersion: String
   def scalaJSVersion = crossScalaJSVersion
   def remoteSourcesPath = s"https://raw.githubusercontent.com/com-lihaoyi/upickle/${publishVersion}/"
+  
   private def sourceMapOption = T.task {
     val baseUrl = pomSettings().url.replace("github.com", "raw.githubusercontent.com")
     val sourcesOptionName = if(isScala3(crossScalaVersion)) "-scalajs-mapSourceURI" else "-P:scalajs:mapSourceURI"

--- a/build.sc
+++ b/build.sc
@@ -129,7 +129,11 @@ trait CommonJsModule extends CommonPublishModule with ScalaJSModule{
   def platformSegment = "js"
   def crossScalaJSVersion: String
   def scalaJSVersion = crossScalaJSVersion
-  override def scalacOptions = super.scalacOptions()
+  def remoteSourcesPath = s"https://raw.githubusercontent.com/com-lihaoyi/upickle/${publishVersion}/"
+  def sourcesOptionName = if (crossScalaJSVersion.startsWith("2.")) "-P:scalajs:mapSourceURI" else "-scalajs-mapSourceURI"
+  override def scalacOptions = super.scalacOptions() ++ Seq(
+    s"${sourcesOptionName}:$millSourcePath->$remoteSourcesPath"
+  )
   override def millSourcePath = super.millSourcePath / os.up / os.up
   trait Tests extends super.Tests with CommonTestModule{
     def platformSegment = "js"

--- a/build.sc
+++ b/build.sc
@@ -130,15 +130,13 @@ trait CommonJsModule extends CommonPublishModule with ScalaJSModule{
   def crossScalaJSVersion: String
   def scalaJSVersion = crossScalaJSVersion
   def remoteSourcesPath = s"https://raw.githubusercontent.com/com-lihaoyi/upickle/${publishVersion}/"
-  def sourcesOptionName = 
-    if(scalaVersion == scala211 || scalaVersion == scala212) {  
-      Seq[String]()
-    } else {
-      Seq(if (crossScalaJSVersion.startsWith("2.")) "-P:scalajs:mapSourceURI" else "-scalajs-mapSourceURI")
-    }    
-  override def scalacOptions = super.scalacOptions() ++ Seq(
-     s"${sourcesOptionName}:$millSourcePath->$remoteSourcesPath"
-  )
+  private def sourceMapOption = T.task {
+    val baseUrl = pomSettings().url.replace("github.com", "raw.githubusercontent.com")
+    val sourcesOptionName = if(isScala3(crossScalaVersion)) "-scalajs-mapSourceURI" else "-P:scalajs:mapSourceURI"
+    s"$sourcesOptionName:${T.workspace}/->$baseUrl/${publishVersion()}/"
+  }   
+  override def scalacOptions = super.scalacOptions() ++ Seq(sourceMapOption())
+
   override def millSourcePath = super.millSourcePath / os.up / os.up
   trait Tests extends super.Tests with CommonTestModule{
     def platformSegment = "js"

--- a/build.sc
+++ b/build.sc
@@ -130,9 +130,14 @@ trait CommonJsModule extends CommonPublishModule with ScalaJSModule{
   def crossScalaJSVersion: String
   def scalaJSVersion = crossScalaJSVersion
   def remoteSourcesPath = s"https://raw.githubusercontent.com/com-lihaoyi/upickle/${publishVersion}/"
-  def sourcesOptionName = if (crossScalaJSVersion.startsWith("2.")) "-P:scalajs:mapSourceURI" else "-scalajs-mapSourceURI"
+  def sourcesOptionName = 
+    if(scalaVersion == scala211 || scalaVersion == scala212) {  
+      Seq[String]()
+    } else {
+      Seq(if (crossScalaJSVersion.startsWith("2.")) "-P:scalajs:mapSourceURI" else "-scalajs-mapSourceURI")
+    }    
   override def scalacOptions = super.scalacOptions() ++ Seq(
-    s"${sourcesOptionName}:$millSourcePath->$remoteSourcesPath"
+     s"${sourcesOptionName}:$millSourcePath->$remoteSourcesPath"
   )
   override def millSourcePath = super.millSourcePath / os.up / os.up
   trait Tests extends super.Tests with CommonTestModule{

--- a/build.sc
+++ b/build.sc
@@ -129,7 +129,6 @@ trait CommonJsModule extends CommonPublishModule with ScalaJSModule{
   def platformSegment = "js"
   def crossScalaJSVersion: String
   def scalaJSVersion = crossScalaJSVersion
-  def remoteSourcesPath = s"https://raw.githubusercontent.com/com-lihaoyi/upickle/${publishVersion}/"
   
   private def sourceMapOptions = T.task {
     val vcsState = VcsVersion.vcsState()


### PR DESCRIPTION
My attempt to fix #431 

I haven't been able to test this at all. I think the solution is "spiritually" correct, but getting upickle to build in my environment, is not a trivial undertaking. I'll try it on a home computer once I get the chance. I'm also not sure, if this should be a very different place in upickle or mill itself - making it a bit of a shot in the dark to debug through CI right now.

The idea is stolen from here; 
https://github.com/raquo/Laminar/blob/739cc0dbab319c685f28be30a1592b7d04347842/build.sbt#L78