### PR TITLE
Reproduction for issue #416

### DIFF
--- a/upickle/test/src/upickle/AdvancedTests.scala
+++ b/upickle/test/src/upickle/AdvancedTests.scala
@@ -339,6 +339,36 @@ object AdvancedTests extends TestSuite {
         val result = upickle.default.read[Node371](input)
         assert(result == expected)
       }
+      test("issue-416"){
+        def zeroHashCodeStrings: Iterator[String] = {
+          def charAndHash(h: Int): Iterator[(Char, Int)] = ('!' to '~').iterator.map(ch => (ch, (h + ch) * 31))
+
+          for {
+            (ch0, h0) <- charAndHash(0)
+            (ch1, h1) <- charAndHash(h0)
+            (ch2, h2) <- charAndHash(h1) if ((h2 + 32) * 923521 ^ (h2 + 127) * 923521) < 0
+            (ch3, h3) <- charAndHash(h2) if ((h3 + 32) * 29791 ^ (h3 + 127) * 29791) < 0
+            (ch4, h4) <- charAndHash(h3) if ((h4 + 32) * 961 ^ (h4 + 127) * 961) < 0
+            (ch5, h5) <- charAndHash(h4) if ((h5 + 32) * 31 ^ (h5 + 127) * 31) < 0
+            (ch6, h6) <- charAndHash(h5) if (h6 + 32 ^ h6 + 127) < 0
+            (ch7, _) <- charAndHash(h6) if h6 + ch7 == 0
+          } yield new String(Array(ch0, ch1, ch2, ch3, ch4, ch5, ch6, ch7))
+        }
+
+        val jsonString =
+          zeroHashCodeStrings
+            .map(s => ujson.write(s))
+            .take(1000000)
+            .mkString("{", s":null,", ":null}")
+
+        // This is expected to have sub-linear behavior, due to use of `LinkedHashMap` in `ujson.Value`
+        // which is not robust against collisions
+        //        ujson.read(jsonString)
+
+        // Make sure this can pass in Scala 3. We do not use `ujson.Value` in this code path at all,
+        // so it should finish in a reasonable amount of time and without issue
+        upickle.default.read[Foo416](jsonString)
+      }
     }
   }
 
@@ -348,6 +378,10 @@ object AdvancedTests extends TestSuite {
     implicit val nodeRW: ReadWriter[Node371] = macroRW[Node371]
   }
 
+  case class Foo416()
+  object Foo416 {
+    implicit val rw: ReadWriter[Foo416] = macroRW[Foo416]
+  }
   class Thing[T: upickle.default.Writer, V: upickle.default.Writer](t: Option[(V, T)]) {
     implicitly[upickle.default.Writer[Option[(V, T)]]]
   }

--- a/upickle/test/src/upickle/AdvancedTests.scala
+++ b/upickle/test/src/upickle/AdvancedTests.scala
@@ -333,7 +333,19 @@ object AdvancedTests extends TestSuite {
       //        rw(TypedFoo.Baz("lol"): TypedFoo, """{"$type": "upickle.TypedFoo.Baz", "s": "lol"}""")
       //        rw(TypedFoo.Quz(true): TypedFoo, """{"$type": "upickle.TypedFoo.Quz", "b": true}""")
       //      }
+      test("issue-371") {
+        val input = """{"head":"a","tail":[{"head":"b","tail":[]}]}"""
+        val expected = Node371("a", Some(Node371("b", None)))
+        val result = upickle.default.read[Node371](input)
+        assert(result == expected)
+      }
     }
+  }
+
+  case class Node371(head: String, tail: Option[Node371])
+
+  object Node371 {
+    implicit val nodeRW: ReadWriter[Node371] = macroRW[Node371]
   }
 
   class Thing[T: upickle.default.Writer, V: upickle.default.Writer](t: Option[(V, T)]) {


### PR DESCRIPTION
It appears the pathological behavior is gone, and this test can now pass successfully on both Scala 2 and Scala 3.

It takes ~2x as long on Scala 3 as Scala 2 (~16s vs ~8s), not obvious why, but at least the "hangs forever" behavior seems to be gone