### PR TITLE
Normalize handling of Scala 3 enums, remove allocations from reader

### DIFF
--- a/core/src/upickle/core/Types.scala
+++ b/core/src/upickle/core/Types.scala
@@ -203,14 +203,6 @@ trait Types{ types =>
   abstract class CaseR[V] extends SimpleReader[V]{
     override def expectedMsg = "expected dictionary"
     override def visitString(s: CharSequence, index: Int) = visitObject(0, true, index).visitEnd(index)
-    trait BaseCaseObjectContext{
-      def storeAggregatedValue(currentIndex: Int, v: Any): Unit
-      def visitKey(index: Int) = _root_.upickle.core.StringVisitor
-      var currentIndex = -1
-      protected def storeValueIfNotFound(i: Int, v: Any): Unit
-      protected def errorMissingKeys(rawArgsLength: Int, mappedArgs: Array[String]): Unit
-      protected def checkErrorMissingKeys(rawArgsBitset: Long): Boolean
-    }
 
     abstract class CaseObjectContext(fieldCount: Int) extends ObjVisitor[Any, V] with BaseCaseObjectContext{
       var found = 0L
@@ -222,7 +214,7 @@ trait Types{ types =>
         }
       }
 
-      protected def storeValueIfNotFound(i: Int, v: Any) = {
+      def storeValueIfNotFound(i: Int, v: Any) = {
         if ((found & (1L << i)) == 0) {
           found |= (1L << i)
           storeAggregatedValue(i, v)
@@ -251,7 +243,7 @@ trait Types{ types =>
         }
       }
 
-      protected def storeValueIfNotFound(i: Int, v: Any) = {
+      def storeValueIfNotFound(i: Int, v: Any) = {
         if ((found(i / 64) & (1L << i)) == 0) {
           found(i / 64) |= (1L << i)
           storeAggregatedValue(i, v)
@@ -416,4 +408,18 @@ object Annotator{
     case class Cls(c: Class[_]) extends Checker
     case class Val(v: Any) extends Checker
   }
+}
+
+trait BaseCaseObjectContext {
+  def storeAggregatedValue(currentIndex: Int, v: Any): Unit
+
+  def visitKey(index: Int) = _root_.upickle.core.StringVisitor
+
+  var currentIndex = -1
+
+  def storeValueIfNotFound(i: Int, v: Any): Unit
+
+  protected def errorMissingKeys(rawArgsLength: Int, mappedArgs: Array[String]): Unit
+
+  protected def checkErrorMissingKeys(rawArgsBitset: Long): Boolean
 }

--- a/implicits/src-3/upickle/implicits/Readers.scala
+++ b/implicits/src-3/upickle/implicits/Readers.scala
@@ -2,22 +2,19 @@ package upickle.implicits
 
 import compiletime.summonInline
 import deriving.Mirror
-import upickle.core.{Annotator, ObjVisitor, Visitor, Abort}
+import upickle.core.{Annotator, ObjVisitor, Visitor, Abort, BaseCaseObjectContext}
 import upickle.implicits.macros.EnumDescription
 
 trait ReadersVersionSpecific extends MacrosCommon:
   this: upickle.core.Types with Readers with Annotator =>
 
-  class CaseReader[T](visitors0: => Product,
-                      fromProduct: Product => T,
-                      keyToIndex: Map[String, Int],
-                      defaultParams: Array[() => Any],
-                      missingKeyCount: Long) extends CaseR[T] {
-
-    val paramCount = keyToIndex.size
+  abstract class CaseReader[T](paramCount: Int, missingKeyCount: Long) extends CaseR[T] {
+    def visitors0: Product
     lazy val visitors = visitors0
-    lazy val indexToKey = keyToIndex.map(_.swap)
-
+    def fromProduct(p: Product): T
+    def keyToIndex(x: String): Int
+    def allKeysArray: Array[String]
+    def storeDefaults(x: upickle.core.BaseCaseObjectContext): Unit
     trait ObjectContext extends ObjVisitor[Any, T] with BaseCaseObjectContext{
       private val params = new Array[Any](paramCount)
 
@@ -29,21 +26,15 @@ trait ReadersVersionSpecific extends MacrosCommon:
 
       def visitKeyValue(v: Any): Unit =
         val k = objectAttributeKeyReadMap(v.toString).toString
-        currentIndex = keyToIndex.getOrElse(k, -1)
+        currentIndex = keyToIndex(k)
 
       def visitEnd(index: Int): T =
-        var i = 0
-        while (i < paramCount)
-          defaultParams(i) match
-            case null =>
-            case computeDefault => storeValueIfNotFound(i, computeDefault())
-
-          i += 1
+        storeDefaults(this)
 
         // Special-case 64 because java bit shifting ignores any RHS values above 63
         // https://docs.oracle.com/javase/specs/jls/se7/html/jls-15.html#jls-15.19
         if (this.checkErrorMissingKeys(missingKeyCount))
-          this.errorMissingKeys(paramCount, indexToKey.toSeq.sortBy(_._1).map(_._2).toArray)
+          this.errorMissingKeys(paramCount, allKeysArray)
 
         fromProduct(new Product {
           def canEqual(that: Any): Boolean = true
@@ -60,15 +51,15 @@ trait ReadersVersionSpecific extends MacrosCommon:
 
   inline def macroR[T](using m: Mirror.Of[T]): Reader[T] = inline m match {
     case m: Mirror.ProductOf[T] =>
-      val reader = new CaseReader(
-        compiletime.summonAll[Tuple.Map[m.MirroredElemTypes, Reader]],
-        m.fromProduct(_),
-        macros.fieldLabels[T].map(_._2).zipWithIndex.toMap,
-        macros.getDefaultParamsArray[T],
-        macros.checkErrorMissingKeysCount[T]()
-      )
+      val reader = new CaseReader[T](macros.paramsCount[T], macros.checkErrorMissingKeysCount[T]()){
+        override def visitors0 = compiletime.summonAll[Tuple.Map[m.MirroredElemTypes, Reader]]
+        override def fromProduct(p: Product): T = m.fromProduct(p)
+        override def keyToIndex(x: String): Int = macros.keyToIndex[T](x)
+        override def allKeysArray = macros.fieldLabels[T].map(_._2).toArray
+        override def storeDefaults(x: upickle.core.BaseCaseObjectContext): Unit = macros.storeDefaults[T](x)
+      }
 
-      if macros.isSingleton[T] then
+      inline if macros.isSingleton[T] then
         annotate[T](SingletonR[T](valueOf[T]), macros.tagName[T])
       else if macros.isMemberOfSealedHierarchy[T] then
         annotate[T](reader, macros.tagName[T])

--- a/implicits/src-3/upickle/implicits/Writers.scala
+++ b/implicits/src-3/upickle/implicits/Writers.scala
@@ -5,14 +5,10 @@ import upickle.core.Annotator
 import compiletime.{summonInline}
 import deriving.Mirror
 import scala.reflect.ClassTag
-import upickle.core.{ Visitor, ObjVisitor, Annotator }
+import upickle.core.{ Visitor, ObjVisitor, Annotator, AnnotatorChecker }
 
 trait WritersVersionSpecific extends MacrosCommon:
   outerThis: upickle.core.Types with Writers with Annotator =>
-
-  class EnumWriter[T] extends Writer[T] :
-    override def write0[V](out: Visitor[_, V], v: T): V = out.visitString(v.toString, -1)
-  end EnumWriter
 
   inline def macroW[T: ClassTag](using m: Mirror.Of[T]): Writer[T] = inline m match {
     case m: Mirror.ProductOf[T] =>
@@ -28,19 +24,18 @@ trait WritersVersionSpecific extends MacrosCommon:
           )
       }
 
-      if macros.isSingleton[T] then annotate(SingletonW[T](null.asInstanceOf[T]), macros.fullClassName[T])
-      else if macros.isMemberOfSealedHierarchy[T] then annotate(writer, macros.fullClassName[T])
+      inline if macros.isSingleton[T] then
+        annotate[T](SingletonW[T](null.asInstanceOf[T]), macros.tagName[T], AnnotatorChecker.Val(valueOf[T]))
+      else if macros.isMemberOfSealedHierarchy[T] then
+        annotate[T](writer, macros.tagName[T], AnnotatorChecker.Cls(implicitly[ClassTag[T]].runtimeClass))
       else writer
 
     case _: Mirror.SumOf[T] =>
-      inline compiletime.erasedValue[T] match {
-        case _: scala.reflect.Enum => new EnumWriter[T]
-        case _ =>
-          val writers: List[Writer[_ <: T]] = compiletime.summonAll[Tuple.Map[m.MirroredElemTypes, Writer]]
-            .toList
-            .asInstanceOf[List[Writer[_ <: T]]]
-          Writer.merge[T](writers: _*)
-      }
+      val writers: List[Writer[_ <: T]] = compiletime.summonAll[Tuple.Map[m.MirroredElemTypes, Writer]]
+        .toList
+        .asInstanceOf[List[Writer[_ <: T]]]
+
+      Writer.merge[T](writers: _*): Writer[T]
   }
 
   inline given[T <: Singleton : Mirror.Of : ClassTag]: Writer[T] = macroW[T]

--- a/implicits/src-3/upickle/implicits/Writers.scala
+++ b/implicits/src-3/upickle/implicits/Writers.scala
@@ -5,7 +5,7 @@ import upickle.core.Annotator
 import compiletime.{summonInline}
 import deriving.Mirror
 import scala.reflect.ClassTag
-import upickle.core.{ Visitor, ObjVisitor, Annotator, AnnotatorChecker }
+import upickle.core.{ Visitor, ObjVisitor, Annotator }
 
 trait WritersVersionSpecific extends MacrosCommon:
   outerThis: upickle.core.Types with Writers with Annotator =>
@@ -25,9 +25,9 @@ trait WritersVersionSpecific extends MacrosCommon:
       }
 
       inline if macros.isSingleton[T] then
-        annotate[T](SingletonW[T](null.asInstanceOf[T]), macros.tagName[T], AnnotatorChecker.Val(valueOf[T]))
+        annotate[T](SingletonW[T](null.asInstanceOf[T]), macros.tagName[T], Annotator.Checker.Val(valueOf[T]))
       else if macros.isMemberOfSealedHierarchy[T] then
-        annotate[T](writer, macros.tagName[T], AnnotatorChecker.Cls(implicitly[ClassTag[T]].runtimeClass))
+        annotate[T](writer, macros.tagName[T], Annotator.Checker.Cls(implicitly[ClassTag[T]].runtimeClass))
       else writer
 
     case _: Mirror.SumOf[T] =>

--- a/implicits/src-3/upickle/implicits/macros.scala
+++ b/implicits/src-3/upickle/implicits/macros.scala
@@ -109,6 +109,7 @@ def writeSnippetsImpl[R, T, WS <: Tuple](thisOuter: Expr[upickle.core.Types with
 
   Expr.block(
     for (((rawLabel, label), i) <- fieldLabelsImpl0[T].zipWithIndex) yield {
+
       val tpe0 = TypeRepr.of[T].memberType(rawLabel).asType
       tpe0 match
       case '[tpe] =>
@@ -149,7 +150,6 @@ def tagNameImpl[T](using Quotes, Type[T]): Expr[String] =
   extractKey(sym) match
   case Some(name) => Expr(name)
   case None =>
-
     // In Scala 3 enums, we use the short name of each case as the tag, rather
     // than the fully-qualified name. We can do this because we know that all
     // enum cases are in the same `enum Foo` namespace with distinct short names,

--- a/implicits/src-3/upickle/implicits/macros.scala
+++ b/implicits/src-3/upickle/implicits/macros.scala
@@ -57,7 +57,8 @@ def fieldLabelsImpl0[T](using Quotes, Type[T]): List[(quotes.reflect.Symbol, Str
     .flatten
     .filterNot(_.isType)
 
-  fields.map{ sym =>
+  if (TypeRepr.of[T].isSingleton) Nil
+  else fields.map{ sym =>
     extractKey(sym) match
     case Some(name) => (sym, name)
     case None => (sym, sym.name)
@@ -108,7 +109,6 @@ def writeSnippetsImpl[R, T, WS <: Tuple](thisOuter: Expr[upickle.core.Types with
 
   Expr.block(
     for (((rawLabel, label), i) <- fieldLabelsImpl0[T].zipWithIndex) yield {
-
       val tpe0 = TypeRepr.of[T].memberType(rawLabel).asType
       tpe0 match
       case '[tpe] =>
@@ -151,7 +151,7 @@ def tagNameImpl[T](using Quotes, Type[T]): Expr[String] =
   case None =>
 
     if (sym.flags.is(Flags.Enum)) Expr(sym.name.filter(_ != '$'))
-    else Expr(sym.fullName.filter(_ != '$'))
+    else Expr(TypeTree.of[T].tpe.typeSymbol.fullName.filter(_ != '$'))
 
 inline def enumValueOf[T]: String => T = ${ enumValueOfImpl[T] }
 def enumValueOfImpl[T](using Quotes, Type[T]): Expr[String => T] =

--- a/implicits/src-3/upickle/implicits/macros.scala
+++ b/implicits/src-3/upickle/implicits/macros.scala
@@ -150,6 +150,13 @@ def tagNameImpl[T](using Quotes, Type[T]): Expr[String] =
   case Some(name) => Expr(name)
   case None =>
 
+    // In Scala 3 enums, we use the short name of each case as the tag, rather
+    // than the fully-qualified name. We can do this because we know that all
+    // enum cases are in the same `enum Foo` namespace with distinct short names,
+    // whereas sealed trait instances could be all over the place with identical
+    // short names only distinguishable by their prefix.
+    //
+    // Harmonizing these two cases further is TBD
     if (sym.flags.is(Flags.Enum)) Expr(sym.name.filter(_ != '$'))
     else Expr(TypeTree.of[T].tpe.typeSymbol.fullName.filter(_ != '$'))
 

--- a/implicits/src-3/upickle/implicits/macros.scala
+++ b/implicits/src-3/upickle/implicits/macros.scala
@@ -140,15 +140,18 @@ def isMemberOfSealedHierarchyImpl[T](using Quotes, Type[T]): Expr[Boolean] =
 
   Expr(parents.exists { p => p.flags.is(Flags.Sealed) })
 
-inline def fullClassName[T]: String = ${ fullClassNameImpl[T] }
-def fullClassNameImpl[T](using Quotes, Type[T]): Expr[String] =
+inline def tagName[T]: String = ${ tagNameImpl[T] }
+def tagNameImpl[T](using Quotes, Type[T]): Expr[String] =
   import quotes.reflect._
 
   val sym = TypeTree.of[T].symbol
 
   extractKey(sym) match
   case Some(name) => Expr(name)
-  case None => Expr(TypeTree.of[T].tpe.typeSymbol.fullName.filter(_ != '$'))
+  case None =>
+
+    if (sym.flags.is(Flags.Enum)) Expr(sym.name.filter(_ != '$'))
+    else Expr(sym.fullName.filter(_ != '$'))
 
 inline def enumValueOf[T]: String => T = ${ enumValueOfImpl[T] }
 def enumValueOfImpl[T](using Quotes, Type[T]): Expr[String => T] =

--- a/upickle/src/upickle/Api.scala
+++ b/upickle/src/upickle/Api.scala
@@ -166,8 +166,8 @@ object legacy extends LegacyApi
 trait LegacyApi extends Api with Annotator{
   def annotate[V](rw: CaseR[V], n: String) = new TaggedReader.Leaf[V](n, rw)
 
-  def annotate[V](rw: CaseW[V], n: String)(implicit c: ClassTag[V]) = {
-    new TaggedWriter.Leaf[V](c, n, rw)
+  def annotate[V](rw: CaseW[V], n: String, checker: AnnotatorChecker): TaggedWriter[V] = {
+    new TaggedWriter.Leaf[V](checker, n, rw)
   }
 
   def taggedExpectedMsg = "expected sequence"
@@ -227,8 +227,8 @@ trait AttributeTagged extends Api with Annotator{
     new TaggedReader.Leaf[V](n, rw)
   }
 
-  def annotate[V](rw: CaseW[V], n: String)(implicit c: ClassTag[V]) = {
-    new TaggedWriter.Leaf[V](c, n, rw)
+  def annotate[V](rw: CaseW[V], n: String, checker: AnnotatorChecker): TaggedWriter[V] = {
+    new TaggedWriter.Leaf[V](checker, n, rw)
   }
 
   def taggedExpectedMsg = "expected dictionary"

--- a/upickle/src/upickle/Api.scala
+++ b/upickle/src/upickle/Api.scala
@@ -166,7 +166,7 @@ object legacy extends LegacyApi
 trait LegacyApi extends Api with Annotator{
   def annotate[V](rw: CaseR[V], n: String) = new TaggedReader.Leaf[V](n, rw)
 
-  def annotate[V](rw: CaseW[V], n: String, checker: AnnotatorChecker): TaggedWriter[V] = {
+  def annotate[V](rw: CaseW[V], n: String, checker: Annotator.Checker): TaggedWriter[V] = {
     new TaggedWriter.Leaf[V](checker, n, rw)
   }
 
@@ -227,7 +227,7 @@ trait AttributeTagged extends Api with Annotator{
     new TaggedReader.Leaf[V](n, rw)
   }
 
-  def annotate[V](rw: CaseW[V], n: String, checker: AnnotatorChecker): TaggedWriter[V] = {
+  def annotate[V](rw: CaseW[V], n: String, checker: Annotator.Checker): TaggedWriter[V] = {
     new TaggedWriter.Leaf[V](checker, n, rw)
   }
 

--- a/upickle/test/src-3/upickle/EnumTests.scala
+++ b/upickle/test/src-3/upickle/EnumTests.scala
@@ -26,9 +26,6 @@ enum ColorEnum(val rgb: Int):
   case Unknown(mix: Int) extends ColorEnum(0x000000)
 
 object ColorEnum{
-  implicit val rwRed: ReadWriter[ColorEnum.Red.type] = macroRW
-  implicit val rwGreen: ReadWriter[ColorEnum.Green.type] = macroRW
-  implicit val rwBlue: ReadWriter[ColorEnum.Blue.type] = macroRW
   implicit val rwMix: ReadWriter[ColorEnum.Mix] = macroRW
   implicit val rwUnknown: ReadWriter[ColorEnum.Unknown] = macroRW
   implicit val rwColor: ReadWriter[ColorEnum] = macroRW

--- a/upickle/test/src-3/upickle/EnumTests.scala
+++ b/upickle/test/src-3/upickle/EnumTests.scala
@@ -11,28 +11,51 @@ import upickle.default.*
 enum SimpleEnum derives ReadWriter:
   case A, B
 
+sealed trait FooX derives ReadWriter
+object FooX{
+  case object Foo1 extends FooX
+  case object Foo2 extends FooX
+
+}
 case class Enclosing(str: String, simple1: SimpleEnum, simple2: Option[SimpleEnum]) derives ReadWriter
 
 object EnumTests extends TestSuite {
+//  enum Color(val rgb: Int):
+//    case Red extends Color(0xFF0000)
+//    case Green extends Color(0x00FF00)
+//    case Blue extends Color(0x0000FF)
+//    case Mix(mix: Int) extends Color(mix)
+//
+//
+//  implicit val rwMix: ReadWriter[Color.Mix] = macroRW
+//  implicit val rwColor: ReadWriter[Color] = macroRW
+
   val tests = Tests {
     test("simple") {
-      test("enum write") - {
-        assert(write(SimpleEnum.A) == "\"A\"")
-        assert(write(SimpleEnum.B) == "\"B\"")
+      test("write") - {
+        assert(write[SimpleEnum](SimpleEnum.A) == "\"A\"")
+        assert(write[SimpleEnum](SimpleEnum.B) == "\"B\"")
+        assert(write[SimpleEnum.A.type](SimpleEnum.A) == "\"A\"")
+        assert(write[SimpleEnum.B.type](SimpleEnum.B) == "\"B\"")
       }
 
-      test("enum read") - {
+      test("read") - {
+        assert(read[SimpleEnum.A.type]("\"A\"") == SimpleEnum.A)
+        assert(read[SimpleEnum.B.type]("\"B\"") == SimpleEnum.B)
         assert(read[SimpleEnum]("\"A\"") == SimpleEnum.A)
         assert(read[SimpleEnum]("\"B\"") == SimpleEnum.B)
       }
 
-      test("enum read failure") - {
+      test("readFailure2") - {
+        read[FooX]("\"C\"")
+      }
+      test("readFailure") - {
         val ex = intercept[AbortException] { read[SimpleEnum]("\"C\"") }
         val expectedMessage = "Value 'C' was not found in enumeration SimpleEnum[values: A, B] at index 0"
         assert(ex.getMessage == expectedMessage)
       }
 
-      test("enclosing write") - {
+      test("enclosingWrite") - {
         val written = write(Enclosing("test", SimpleEnum.A, Some(SimpleEnum.B)))
         val expected = """{"str":"test","simple1":"A","simple2":["B"]}"""
         assert(written == expected)

--- a/upickle/test/src-3/upickle/EnumTests.scala
+++ b/upickle/test/src-3/upickle/EnumTests.scala
@@ -1,6 +1,7 @@
 package upickle
 
 import ujson.ParseException
+import upickle.TestUtil.rw
 import upickle.core.AbortException
 
 import scala.language.implicitConversions
@@ -15,51 +16,62 @@ sealed trait FooX derives ReadWriter
 object FooX{
   case object Foo1 extends FooX
   case object Foo2 extends FooX
-
 }
+
+enum ColorEnum(val rgb: Int):
+  case Red extends ColorEnum(0xFF0000)
+  case Green extends ColorEnum(0x00FF00)
+  case Blue extends ColorEnum(0x0000FF)
+  case Mix(mix: Int) extends ColorEnum(mix)
+  case Unknown(mix: Int) extends ColorEnum(0x000000)
+
+object ColorEnum{
+  implicit val rwRed: ReadWriter[ColorEnum.Red.type] = macroRW
+  implicit val rwGreen: ReadWriter[ColorEnum.Green.type] = macroRW
+  implicit val rwBlue: ReadWriter[ColorEnum.Blue.type] = macroRW
+  implicit val rwMix: ReadWriter[ColorEnum.Mix] = macroRW
+  implicit val rwUnknown: ReadWriter[ColorEnum.Unknown] = macroRW
+  implicit val rwColor: ReadWriter[ColorEnum] = macroRW
+}
+
 case class Enclosing(str: String, simple1: SimpleEnum, simple2: Option[SimpleEnum]) derives ReadWriter
 
 object EnumTests extends TestSuite {
-//  enum Color(val rgb: Int):
-//    case Red extends Color(0xFF0000)
-//    case Green extends Color(0x00FF00)
-//    case Blue extends Color(0x0000FF)
-//    case Mix(mix: Int) extends Color(mix)
-//
-//
-//  implicit val rwMix: ReadWriter[Color.Mix] = macroRW
-//  implicit val rwColor: ReadWriter[Color] = macroRW
 
   val tests = Tests {
     test("simple") {
-      test("write") - {
-        assert(write[SimpleEnum](SimpleEnum.A) == "\"A\"")
-        assert(write[SimpleEnum](SimpleEnum.B) == "\"B\"")
-        assert(write[SimpleEnum.A.type](SimpleEnum.A) == "\"A\"")
-        assert(write[SimpleEnum.B.type](SimpleEnum.B) == "\"B\"")
+      test("readwrite") - {
+        rw[SimpleEnum](SimpleEnum.A, "\"A\"")
+        rw[SimpleEnum](SimpleEnum.B, "\"B\"")
+        rw[SimpleEnum.A.type](SimpleEnum.A, "\"A\"")
+        rw[SimpleEnum.B.type](SimpleEnum.B, "\"B\"")
       }
 
-      test("read") - {
-        assert(read[SimpleEnum.A.type]("\"A\"") == SimpleEnum.A)
-        assert(read[SimpleEnum.B.type]("\"B\"") == SimpleEnum.B)
-        assert(read[SimpleEnum]("\"A\"") == SimpleEnum.A)
-        assert(read[SimpleEnum]("\"B\"") == SimpleEnum.B)
-      }
-
-      test("readFailure2") - {
-        read[FooX]("\"C\"")
-      }
       test("readFailure") - {
         val ex = intercept[AbortException] { read[SimpleEnum]("\"C\"") }
-        val expectedMessage = "Value 'C' was not found in enumeration SimpleEnum[values: A, B] at index 0"
+        val expectedMessage = "invalid tag for tagged object: C at index 0"
         assert(ex.getMessage == expectedMessage)
       }
 
       test("enclosingWrite") - {
-        val written = write(Enclosing("test", SimpleEnum.A, Some(SimpleEnum.B)))
-        val expected = """{"str":"test","simple1":"A","simple2":["B"]}"""
-        assert(written == expected)
+        rw(
+          Enclosing("test", SimpleEnum.A, Some(SimpleEnum.B)),
+          """{"str":"test","simple1":"A","simple2":["B"]}"""
+        )
       }
+    }
+    test("color"){
+      rw[ColorEnum](ColorEnum.Red, "\"Red\"")
+      rw[ColorEnum](ColorEnum.Green, "\"Green\"")
+      rw[ColorEnum](ColorEnum.Blue, "\"Blue\"")
+      rw[ColorEnum](ColorEnum.Mix(12345), "{\"$type\":\"Mix\",\"mix\":12345}")
+      rw[ColorEnum](ColorEnum.Unknown(12345), "{\"$type\":\"Unknown\",\"mix\":12345}")
+
+      rw[ColorEnum.Red.type](ColorEnum.Red, "\"Red\"")
+      rw[ColorEnum.Green.type](ColorEnum.Green, "\"Green\"")
+      rw[ColorEnum.Blue.type](ColorEnum.Blue, "\"Blue\"")
+      rw[ColorEnum.Mix](ColorEnum.Mix(12345), "{\"$type\":\"Mix\",\"mix\":12345}")
+      rw[ColorEnum.Unknown](ColorEnum.Unknown(12345), "{\"$type\":\"Unknown\",\"mix\":12345}")
     }
   }
 }

--- a/upickle/test/src/upickle/AdvancedTests.scala
+++ b/upickle/test/src/upickle/AdvancedTests.scala
@@ -339,6 +339,36 @@ object AdvancedTests extends TestSuite {
         val result = upickle.default.read[Node371](input)
         assert(result == expected)
       }
+      test("issue-416"){
+        def zeroHashCodeStrings: Iterator[String] = {
+          def charAndHash(h: Int): Iterator[(Char, Int)] = ('!' to '~').iterator.map(ch => (ch, (h + ch) * 31))
+
+          for {
+            (ch0, h0) <- charAndHash(0)
+            (ch1, h1) <- charAndHash(h0)
+            (ch2, h2) <- charAndHash(h1) if ((h2 + 32) * 923521 ^ (h2 + 127) * 923521) < 0
+            (ch3, h3) <- charAndHash(h2) if ((h3 + 32) * 29791 ^ (h3 + 127) * 29791) < 0
+            (ch4, h4) <- charAndHash(h3) if ((h4 + 32) * 961 ^ (h4 + 127) * 961) < 0
+            (ch5, h5) <- charAndHash(h4) if ((h5 + 32) * 31 ^ (h5 + 127) * 31) < 0
+            (ch6, h6) <- charAndHash(h5) if (h6 + 32 ^ h6 + 127) < 0
+            (ch7, _) <- charAndHash(h6) if h6 + ch7 == 0
+          } yield new String(Array(ch0, ch1, ch2, ch3, ch4, ch5, ch6, ch7))
+        }
+
+        val jsonString =
+          zeroHashCodeStrings
+            .map(s => ujson.write(s))
+            .take(1000000)
+            .mkString("{", s":null,", ":null}")
+
+        // This is expected to have sub-linear behavior, due to use of `LinkedHashMap` in `ujson.Value`
+        // which is not robust against collisions
+        //        ujson.read(jsonString)
+
+        // Make sure this can pass in Scala 3. We do not use `ujson.Value` in this code path at all,
+        // so it should finish in a reasonable amount of time and without issue
+        upickle.default.read[Foo416](jsonString)
+      }
     }
   }
 
@@ -348,6 +378,10 @@ object AdvancedTests extends TestSuite {
     implicit val nodeRW: ReadWriter[Node371] = macroRW[Node371]
   }
 
+  case class Foo416()
+  object Foo416 {
+    implicit val rw: ReadWriter[Foo416] = macroRW[Foo416]
+  }
   class Thing[T: upickle.default.Writer, V: upickle.default.Writer](t: Option[(V, T)]) {
     implicitly[upickle.default.Writer[Option[(V, T)]]]
   }

--- a/upickle/test/src/upickle/AdvancedTests.scala
+++ b/upickle/test/src/upickle/AdvancedTests.scala
@@ -333,12 +333,14 @@ object AdvancedTests extends TestSuite {
       //        rw(TypedFoo.Baz("lol"): TypedFoo, """{"$type": "upickle.TypedFoo.Baz", "s": "lol"}""")
       //        rw(TypedFoo.Quz(true): TypedFoo, """{"$type": "upickle.TypedFoo.Quz", "b": true}""")
       //      }
+
       test("issue-371") {
         val input = """{"head":"a","tail":[{"head":"b","tail":[]}]}"""
         val expected = Node371("a", Some(Node371("b", None)))
         val result = upickle.default.read[Node371](input)
         assert(result == expected)
       }
+
       test("issue-416"){
         def zeroHashCodeStrings: Iterator[String] = {
           def charAndHash(h: Int): Iterator[(Char, Int)] = ('!' to '~').iterator.map(ch => (ch, (h + ch) * 31))

--- a/upickle/test/src/upickle/AdvancedTests.scala
+++ b/upickle/test/src/upickle/AdvancedTests.scala
@@ -333,7 +333,19 @@ object AdvancedTests extends TestSuite {
       //        rw(TypedFoo.Baz("lol"): TypedFoo, """{"$type": "upickle.TypedFoo.Baz", "s": "lol"}""")
       //        rw(TypedFoo.Quz(true): TypedFoo, """{"$type": "upickle.TypedFoo.Quz", "b": true}""")
       //      }
+      test("issue-371") {
+        val input = """{"head":"a","tail":[{"head":"b","tail":[]}]}"""
+        val expected = Node371("a", Some(Node371("b", None)))
+        val result = upickle.default.read[Node371](input)
+        assert(result == expected)
+      }
     }
+  }
+
+  case class Node371(head: String, tail: Option[Node371])
+
+  object Node371 {
+    implicit val nodeRW: ReadWriter[Node371] = macroRW[Node371]
   }
 
   class Thing[T: upickle.default.Writer, V: upickle.default.Writer](t: Option[(V, T)]) {

--- a/upickle/test/src/upickle/FailureTests.scala
+++ b/upickle/test/src/upickle/FailureTests.scala
@@ -23,6 +23,20 @@ object Fi{
     implicit def rw2: upickle.default.ReadWriter[Fum] = upickle.default.macroRW
   }
 }
+
+sealed trait WrongTag
+
+object WrongTag {
+  case object Foo1 extends WrongTag
+
+  case object Foo2 extends WrongTag
+  implicit val rw1: upickle.default.ReadWriter[Foo1.type] = upickle.default.macroRW
+  implicit val rw2: upickle.default.ReadWriter[Foo2.type] = upickle.default.macroRW
+  implicit val rw: upickle.default.ReadWriter[WrongTag] = upickle.default.macroRW
+
+
+}
+
 /**
 * Generally, every failure should be a Invalid.Json or a
 * InvalidData. If any assertion errors, match errors, number
@@ -210,8 +224,9 @@ object FailureTests extends TestSuite {
         test("invalidTag"){
           test - assertErrorMsg[Fi.Fo]("""["omg", {}]""", "invalid tag for tagged object: omg at index 1")
           test - assertErrorMsg[Fi]("""["omg", {}]""", "invalid tag for tagged object: omg at index 1")
-          test - assertErrorMsgDefault[Fi.Fo]("""{"$type": "omg"}]""", "invalid tag for tagged object: omg at index 1")
-          test - assertErrorMsgDefault[Fi]("""{"$type": "omg"}]""", "invalid tag for tagged object: omg at index 1")
+          test - assertErrorMsgDefault[Fi.Fo]("""{"$type": "omg"}""", "invalid tag for tagged object: omg at index 1")
+          test - assertErrorMsgDefault[Fi](""""omg"""", "invalid tag for tagged object: omg at index 0")
+          test - assertErrorMsgDefault[Fi]("""{"$type": "omg"}""", "invalid tag for tagged object: omg at index 1")
           test - assertErrorMsgDefault[Fi]("""{}""", "expected tagged dictionary")
         }
 

--- a/upickle/test/src/upickle/MacroTests.scala
+++ b/upickle/test/src/upickle/MacroTests.scala
@@ -5,6 +5,7 @@ import upickle.TestUtil._
 import upickle.default.{read, write, ReadWriter => RW}
 
 case class Trivial(a: Int = 1)
+
 case class KeyedPerson(
                    @upickle.implicits.key("first_name") firstName: String = "N/A",
                    @upickle.implicits.key("last_name") lastName: String)
@@ -552,9 +553,9 @@ object MacroTests extends TestSuite {
 
     }
     test("defaultkeyregression"){
-
-      val json = """{"last_name": "Snow"}"""
+      val json = """{"last_name":"Snow"}"""
       upickle.default.read[KeyedPerson](json) ==> KeyedPerson("N/A", "Snow")
+      upickle.default.write[KeyedPerson](KeyedPerson("N/A", "Snow")) ==> json
     }
 
     test("specialchars"){
@@ -565,4 +566,3 @@ object MacroTests extends TestSuite {
     }
   }
 }
-


### PR DESCRIPTION
Fixes #356

The Scala 3 code for handling enums was a parallel code path from that handling sealed hierarchies: going through separate `EnumReader`/`EnumWriter`s, raising separate error messages, and not supporting common use cases. This PR makes Scala 3 enums use the same sealed-trait-handling logic as far as possible, allowing them to support things like parametrized enums and parametrized enum cases. This also reduces the complexity of the code by ensuring both `enum`s and `sealed trait`s go through a common code path, and should help avoid accidental divergence in future

One notable point of divergence is the choice of type tag. Enums use the short name of the type `Foo`, whereas sealed traits use the fully qualified name `pkg.name.Foo`. For now, I leave both behaviors in place, though ideally we should unify them at some point

I also took the opportunity to tweak the Scala 3 `Reader.scala` macros, to move more logic to compile time to better mirror that behavior in Scala 2. This replaces a runtime `Map` in each case class reader with a macro-generated `match` statement, and reduces the number of runtime `Arrays` we need to allocate (though does not quite eliminate all of them, we still have two arrays for `params` and `visitors`)

All existing tests pass, and added new tests to verify the newly-working functionality. 

I'll leave this up for a few days in case anyone wants to review it