### PR TITLE
Be more robust about checking whether objects are modules in Scala3

### DIFF
--- a/implicits/src-3/upickle/implicits/Readers.scala
+++ b/implicits/src-3/upickle/implicits/Readers.scala
@@ -3,7 +3,6 @@ package upickle.implicits
 import compiletime.summonInline
 import deriving.Mirror
 import upickle.core.{Annotator, ObjVisitor, Visitor, Abort, BaseCaseObjectContext}
-import upickle.implicits.macros.EnumDescription
 
 trait ReadersVersionSpecific extends MacrosCommon:
   this: upickle.core.Types with Readers with Annotator =>
@@ -60,7 +59,7 @@ trait ReadersVersionSpecific extends MacrosCommon:
       }
 
       inline if macros.isSingleton[T] then
-        annotate[T](SingletonR[T](valueOf[T]), macros.tagName[T])
+        annotate[T](SingletonR[T](macros.getSingleton[T]), macros.tagName[T])
       else if macros.isMemberOfSealedHierarchy[T] then
         annotate[T](reader, macros.tagName[T])
       else reader

--- a/implicits/src-3/upickle/implicits/Writers.scala
+++ b/implicits/src-3/upickle/implicits/Writers.scala
@@ -25,7 +25,7 @@ trait WritersVersionSpecific extends MacrosCommon:
       }
 
       inline if macros.isSingleton[T] then
-        annotate[T](SingletonW[T](null.asInstanceOf[T]), macros.tagName[T], Annotator.Checker.Val(valueOf[T]))
+        annotate[T](SingletonW[T](null.asInstanceOf[T]), macros.tagName[T], Annotator.Checker.Val(macros.getSingleton[T]))
       else if macros.isMemberOfSealedHierarchy[T] then
         annotate[T](writer, macros.tagName[T], Annotator.Checker.Cls(implicitly[ClassTag[T]].runtimeClass))
       else writer

--- a/implicits/src-3/upickle/implicits/macros.scala
+++ b/implicits/src-3/upickle/implicits/macros.scala
@@ -226,5 +226,5 @@ case m: Mirror.SumOf[T] =>
 inline def isSingleton[T]: Boolean = ${ isSingletonImpl[T] }
 def isSingletonImpl[T](using Quotes, Type[T]): Expr[Boolean] =
   import quotes.reflect._
-  Expr(TypeRepr.of[T].isSingleton)
+  Expr(TypeRepr.of[T].typeSymbol.flags.is(Flags.Module))
 

--- a/upickle/test/src-3/upickle/Derivation.scala
+++ b/upickle/test/src-3/upickle/Derivation.scala
@@ -1,6 +1,7 @@
 package upickle
 
 import scala.language.implicitConversions
+import TestUtil.rw
 import utest._
 
 import upickle.default.{ read, write, Reader, ReadWriter }
@@ -22,110 +23,60 @@ case object Cthulu
   extends Animal
   derives ReadWriter
 
-//sealed trait Animal2
-//case object Cthulu2
-//  extends Animal2
+sealed trait AnimalImplicit
 
+case object CthuluImplicit
+  extends AnimalImplicit
 
 
 object DerivationTests extends TestSuite {
-//  implicit val rwAnimal2: ReadWriter[Animal2] = ReadWriter.derived
-//  implicit val rwCthulu2: ReadWriter[Cthulu2.type] = ReadWriter.derived
+  implicit val rwCthuluImplicit: ReadWriter[CthuluImplicit.type] = ReadWriter.derived
+  implicit val rwAnimalImplicit: ReadWriter[AnimalImplicit] = ReadWriter.derived
   val tests = Tests {
-    test("caseClassReader") - {
-      val dogJson = """
-        {
-          "name": "Ball",
-          "age": 2
-        }
-      """
-      val parsed = read[Dog](dogJson)
-      val expected = Dog("Ball", 2)
-      assert(parsed == expected)
+    test("caseClass") - {
+      rw[Dog](Dog("Ball", 2), """{"name":"Ball","age":2}""")
     }
 
-    test("caseClassTaggedReader") - {
-      val personJson = """
-        {
-          "$type":"upickle.Person",
-          "name": "Peter",
-          "address": "Avenue 10 Zurich"
-        }
-      """
-      val parsed = read[Person](personJson)
-      val expected = Person("Peter", "Avenue 10 Zurich", 20)
-      assert(parsed == expected)
+    test("caseClassTagged") - {
+      rw[Person](
+        Person("Peter", "Avenue 10 Zurich", 20),
+        """{"$type":"upickle.Person","name":"Peter","address":"Avenue 10 Zurich"}"""
+      )
     }
 
-    test("traitReader") - {
-      val personJson = """
-        {
-          "$type":"upickle.Person",
-          "name": "Peter",
-          "address": "Avenue 10 Zurich"
-        }
-      """
-      val parsed = read[Animal](personJson)
-      val expected = Person("Peter", "Avenue 10 Zurich" ,20)
-      assert(parsed == expected)
-    }
-
-    test("caseClassWriter") - {
-      val dog = Dog("Ball", 10)
-      val result = write(dog)
-      val expected = """{"name":"Ball","age":10}"""
-      assert(result == expected)
+    test("trait") - {
+      rw[Animal](
+        Person("Peter", "Avenue 10 Zurich" ,20),
+        """{"$type":"upickle.Person","name":"Peter","address":"Avenue 10 Zurich"}"""
+      )
+      rw[Animal](
+        Person("Peter", "Avenue 10 Zurich"),
+        """{"$type":"upickle.Person","name":"Peter","address":"Avenue 10 Zurich"}"""
+      )
     }
 
     test("caseObjectWriter") - {
-      val result1 = write(Cthulu)
-
-      val animal: Animal = Cthulu
-      val result2 = write(animal)
-
-      val expected = """{"$type":"upickle.Cthulu"}"""
-      assert(result1 == expected)
-      assert(result2 == expected)
+      rw[Animal](Cthulu, """"upickle.Cthulu"""", """{"$type":"upickle.Cthulu"}""")
+      rw[Cthulu.type](Cthulu, """"upickle.Cthulu"""", """{"$type":"upickle.Cthulu"}""")
     }
 
-
-//    test("caseObjectWriterImplicit") - {
-//      val result1 = write(Cthulu2)
-//
-//      val animal: Animal2 = Cthulu2
-//      val result2 = write(animal)
-//
-//      val expected = """{"$type":"upickle.Cthulu2"}"""
-//      assert(result1 == expected)
-//      assert(result2 == expected)
-//    }
-
-    test ("caseObjectReader") - {
-      val json = """{"$type":"upickle.Cthulu"}"""
-      val result = read[Animal](json)
-      assert(result == Cthulu)
+    test("caseObjectWriterImplicit") - {
+      rw[AnimalImplicit](
+        CthuluImplicit, 
+        """"upickle.CthuluImplicit"""",
+         """{"$type":"upickle.CthuluImplicit"}"""
+      )
+      rw[CthuluImplicit.type](
+        CthuluImplicit,
+         """"upickle.CthuluImplicit"""", 
+         """{"$type":"upickle.CthuluImplicit"}"""
+      )
     }
 
-    test("traitWriter") - {
-      val person: Animal = Person("Peter", "Avenue 10 Zurich")
-      val result = write(person)
-      val expected = """{"$type":"upickle.Person","name":"Peter","address":"Avenue 10 Zurich"}"""
-      assert(result == expected)
-    }
-
-    test("readWriter") - {
-      val rw = summon[ReadWriter[Animal]]
-      val person = Person("Peter", "Somewhere", 30)
-      val json = write(person)(rw)
-      val expectedJson = """{"$type":"upickle.Person","name":"Peter","address":"Somewhere","age":30}"""
-      assert(json == expectedJson)
-      val deserialized = read(json)(rw)
-      val expectedDeserialized = Person("Peter", "Somewhere", 30)
-      assert(deserialized == expectedDeserialized)
-    }
     test("recursive"){
       case class Recur(recur: Option[Recur]) derives ReadWriter
-      assert(write(Recur(None)) == """{"recur":[]}""")
+      rw(Recur(None), """{"recur":[]}""")
+      rw(Recur(Some(Recur(None))), """{"recur":[{"recur": []}]}""")
     }
   }
 }

--- a/upickle/test/src-3/upickle/Derivation.scala
+++ b/upickle/test/src-3/upickle/Derivation.scala
@@ -22,8 +22,15 @@ case object Cthulu
   extends Animal
   derives ReadWriter
 
-object DerivationTests extends TestSuite {
+//sealed trait Animal2
+//case object Cthulu2
+//  extends Animal2
 
+
+
+object DerivationTests extends TestSuite {
+//  implicit val rwAnimal2: ReadWriter[Animal2] = ReadWriter.derived
+//  implicit val rwCthulu2: ReadWriter[Cthulu2.type] = ReadWriter.derived
   val tests = Tests {
     test("caseClassReader") - {
       val dogJson = """
@@ -80,6 +87,18 @@ object DerivationTests extends TestSuite {
       assert(result1 == expected)
       assert(result2 == expected)
     }
+
+
+//    test("caseObjectWriterImplicit") - {
+//      val result1 = write(Cthulu2)
+//
+//      val animal: Animal2 = Cthulu2
+//      val result2 = write(animal)
+//
+//      val expected = """{"$type":"upickle.Cthulu2"}"""
+//      assert(result1 == expected)
+//      assert(result2 == expected)
+//    }
 
     test ("caseObjectReader") - {
       val json = """{"$type":"upickle.Cthulu"}"""

--- a/upickle/test/src-3/upickle/EnumTests.scala
+++ b/upickle/test/src-3/upickle/EnumTests.scala
@@ -12,10 +12,10 @@ import upickle.default.*
 enum SimpleEnum derives ReadWriter:
   case A, B
 
-sealed trait FooX derives ReadWriter
-object FooX{
-  case object Foo1 extends FooX
-  case object Foo2 extends FooX
+sealed trait Scala3SealedTrait derives ReadWriter
+object Scala3SealedTrait{
+  case object Case1 extends Scala3SealedTrait derives ReadWriter
+  case class Case2(x: Scala3SealedTrait) extends Scala3SealedTrait derives ReadWriter
 }
 
 enum ColorEnum(val rgb: Int):
@@ -56,6 +56,24 @@ object EnumTests extends TestSuite {
           """{"str":"test","simple1":"A","simple2":["B"]}"""
         )
       }
+    }
+    test("sealedTrait"){
+      rw[Scala3SealedTrait](
+        Scala3SealedTrait.Case2(Scala3SealedTrait.Case1),
+        """{"$type":"upickle.Scala3SealedTrait.Case2","x":"upickle.Scala3SealedTrait.Case1"}"""
+      )
+      rw[Scala3SealedTrait.Case2](
+        Scala3SealedTrait.Case2(Scala3SealedTrait.Case1),
+        """{"$type":"upickle.Scala3SealedTrait.Case2","x":"upickle.Scala3SealedTrait.Case1"}"""
+      )
+      rw[Scala3SealedTrait](
+        Scala3SealedTrait.Case1,
+        """"upickle.Scala3SealedTrait.Case1""""
+      )
+      rw[Scala3SealedTrait.Case1.type](
+        Scala3SealedTrait.Case1,
+        """"upickle.Scala3SealedTrait.Case1""""
+      )
     }
     test("color"){
       rw[ColorEnum](ColorEnum.Red, "\"Red\"")

--- a/upickle/test/src-3/upickle/EnumTests.scala
+++ b/upickle/test/src-3/upickle/EnumTests.scala
@@ -8,15 +8,8 @@ import scala.language.implicitConversions
 import utest.{assert, intercept, *}
 import upickle.default.*
 
-
 enum SimpleEnum derives ReadWriter:
   case A, B
-
-sealed trait Scala3SealedTrait derives ReadWriter
-object Scala3SealedTrait{
-  case object Case1 extends Scala3SealedTrait derives ReadWriter
-  case class Case2(x: Scala3SealedTrait) extends Scala3SealedTrait derives ReadWriter
-}
 
 enum ColorEnum(val rgb: Int):
   case Red extends ColorEnum(0xFF0000)
@@ -56,24 +49,6 @@ object EnumTests extends TestSuite {
           """{"str":"test","simple1":"A","simple2":["B"]}"""
         )
       }
-    }
-    test("sealedTrait"){
-      rw[Scala3SealedTrait](
-        Scala3SealedTrait.Case2(Scala3SealedTrait.Case1),
-        """{"$type":"upickle.Scala3SealedTrait.Case2","x":"upickle.Scala3SealedTrait.Case1"}"""
-      )
-      rw[Scala3SealedTrait.Case2](
-        Scala3SealedTrait.Case2(Scala3SealedTrait.Case1),
-        """{"$type":"upickle.Scala3SealedTrait.Case2","x":"upickle.Scala3SealedTrait.Case1"}"""
-      )
-      rw[Scala3SealedTrait](
-        Scala3SealedTrait.Case1,
-        """"upickle.Scala3SealedTrait.Case1""""
-      )
-      rw[Scala3SealedTrait.Case1.type](
-        Scala3SealedTrait.Case1,
-        """"upickle.Scala3SealedTrait.Case1""""
-      )
     }
     test("color"){
       rw[ColorEnum](ColorEnum.Red, "\"Red\"")

--- a/upickle/test/src-3/upickle/EnumTests.scala
+++ b/upickle/test/src-3/upickle/EnumTests.scala
@@ -31,10 +31,10 @@ object EnumTests extends TestSuite {
   val tests = Tests {
     test("simple") {
       test("readwrite") - {
-        rw[SimpleEnum](SimpleEnum.A, "\"A\"")
-        rw[SimpleEnum](SimpleEnum.B, "\"B\"")
-        rw[SimpleEnum.A.type](SimpleEnum.A, "\"A\"")
-        rw[SimpleEnum.B.type](SimpleEnum.B, "\"B\"")
+        rw[SimpleEnum](SimpleEnum.A, "\"A\"", """{"$type": "A"}""")
+        rw[SimpleEnum](SimpleEnum.B, "\"B\"", """{"$type": "B"}""")
+        rw[SimpleEnum.A.type](SimpleEnum.A, "\"A\"", """{"$type": "A"}""")
+        rw[SimpleEnum.B.type](SimpleEnum.B, "\"B\"", """{"$type": "B"}""")
       }
 
       test("readFailure") - {
@@ -51,15 +51,15 @@ object EnumTests extends TestSuite {
       }
     }
     test("color"){
-      rw[ColorEnum](ColorEnum.Red, "\"Red\"")
-      rw[ColorEnum](ColorEnum.Green, "\"Green\"")
-      rw[ColorEnum](ColorEnum.Blue, "\"Blue\"")
+      rw[ColorEnum](ColorEnum.Red, "\"Red\"", """{"$type": "Red"}""")
+      rw[ColorEnum](ColorEnum.Green, "\"Green\"", """{"$type": "Green"}""")
+      rw[ColorEnum](ColorEnum.Blue, "\"Blue\"", """{"$type": "Blue"}""")
       rw[ColorEnum](ColorEnum.Mix(12345), "{\"$type\":\"Mix\",\"mix\":12345}")
       rw[ColorEnum](ColorEnum.Unknown(12345), "{\"$type\":\"Unknown\",\"mix\":12345}")
 
-      rw[ColorEnum.Red.type](ColorEnum.Red, "\"Red\"")
-      rw[ColorEnum.Green.type](ColorEnum.Green, "\"Green\"")
-      rw[ColorEnum.Blue.type](ColorEnum.Blue, "\"Blue\"")
+      rw[ColorEnum.Red.type](ColorEnum.Red, "\"Red\"", """{"$type": "Red"}""")
+      rw[ColorEnum.Green.type](ColorEnum.Green, "\"Green\"", """{"$type": "Green"}""")
+      rw[ColorEnum.Blue.type](ColorEnum.Blue, "\"Blue\"", """{"$type": "Blue"}""")
       rw[ColorEnum.Mix](ColorEnum.Mix(12345), "{\"$type\":\"Mix\",\"mix\":12345}")
       rw[ColorEnum.Unknown](ColorEnum.Unknown(12345), "{\"$type\":\"Unknown\",\"mix\":12345}")
     }


### PR DESCRIPTION
`.isSingleton` doesn't work reliable in the presence of `derives`, neither does `valueOf[T]`. This PR re-implements our own versions that work properly