### PR TITLE
Add typed Readers and Writers for Java boxed primitives

### DIFF
--- a/implicits/src/upickle/implicits/Readers.scala
+++ b/implicits/src/upickle/implicits/Readers.scala
@@ -30,6 +30,7 @@ trait Readers extends upickle.core.Types
     override def visitNull(index: Int): Unit = ()
   }
 
+
   implicit val BooleanReader: Reader[Boolean] = new SimpleReader[Boolean] {
     override def expectedMsg = "expected boolean"
     override def visitTrue(index: Int) = true
@@ -63,8 +64,8 @@ trait Readers extends upickle.core.Types
     override def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, index: Int) = {
       s.toString.toDouble
     }
-
   }
+
   implicit val IntReader: Reader[Int] = new NumericReader[Int] {
     override def expectedMsg = "expected number"
     override def visitString(s: CharSequence, index: Int) = visitFloat64String(s.toString, index)
@@ -91,7 +92,6 @@ trait Readers extends upickle.core.Types
     override def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, index: Int) = {
       s.toString.toFloat
     }
-
   }
 
   implicit val ShortReader: Reader[Short] = new NumericReader[Short]{
@@ -360,4 +360,17 @@ trait Readers extends upickle.core.Types
     EitherReader[T1, T2].narrow[Right[T1, T2]]
   implicit def LeftReader[T1: Reader, T2: Reader]: Reader[Left[T1, T2]] =
     EitherReader[T1, T2].narrow[Left[T1, T2]]
+
+  private case class JavaReader[T: Reader](){
+    def create[V] = implicitly[Reader[T]].asInstanceOf[Reader[V]]
+  }
+
+  implicit val JavaBooleanReader: Reader[java.lang.Boolean] = JavaReader[Boolean]().create
+  implicit val JavaByteReader: Reader[java.lang.Byte] = JavaReader[Byte]().create
+  implicit val JavaCharReader: Reader[java.lang.Character] = JavaReader[Char]().create
+  implicit val JavaShortReader: Reader[java.lang.Short] = JavaReader[Short]().create
+  implicit val JavaIntReader: Reader[java.lang.Integer] = JavaReader[Int]().create
+  implicit val JavaLongReader: Reader[java.lang.Long] = JavaReader[Long]().create
+  implicit val JavaFloatReader: Reader[java.lang.Float] = JavaReader[Float]().create
+  implicit val JavaDoubleReader: Reader[java.lang.Double] = JavaReader[Double]().create
 }

--- a/implicits/src/upickle/implicits/Writers.scala
+++ b/implicits/src/upickle/implicits/Writers.scala
@@ -186,6 +186,19 @@ trait Writers extends upickle.core.Types
 
   implicit def LeftWriter[T1: Writer, T2: Writer]: Writer[Left[T1, T2]] =
     EitherWriter[T1, T2].narrow[Left[T1, T2]]
+
+  private case class JavaWriter[T: Writer]() {
+    def create[V] = implicitly[Writer[T]].asInstanceOf[Writer[V]]
+  }
+
+  implicit val JavaBooleanWriter: Writer[java.lang.Boolean] = JavaWriter[Boolean]().create
+  implicit val JavaByteWriter: Writer[java.lang.Byte] = JavaWriter[Byte]().create
+  implicit val JavaCharWriter: Writer[java.lang.Character] = JavaWriter[Char]().create
+  implicit val JavaShortWriter: Writer[java.lang.Short] = JavaWriter[Short]().create
+  implicit val JavaIntWriter: Writer[java.lang.Integer] = JavaWriter[Int]().create
+  implicit val JavaLongWriter: Writer[java.lang.Long] = JavaWriter[Long]().create
+  implicit val JavaFloatWriter: Writer[java.lang.Float] = JavaWriter[Float]().create
+  implicit val JavaDoubleWriter: Writer[java.lang.Double] = JavaWriter[Double]().create
 }
 
 /**

--- a/upickle/test/src/upickle/PrimitiveTests.scala
+++ b/upickle/test/src/upickle/PrimitiveTests.scala
@@ -243,5 +243,54 @@ object PrimitiveTests extends TestSuite {
         }
       }
     }
+
+    test("java"){
+      test("bool"){
+        test("value") - rw(true: java.lang.Boolean, "true", "\"true\"", upack.True, upack.Str("true"))
+        test("null") - rw(null: java.lang.Boolean, "null", upack.Null)
+      }
+      test("byte"){
+        test("value") - rw((1: Byte): java.lang.Byte, "1", """ "1" """, upack.Int32(1), upack.Str("1"))
+        test("null") - rw(null: java.lang.Byte, "null", upack.Null)
+      }
+      test("char") {
+        test("value") - rwNoBinaryJson('f': java.lang.Character, """ "f" """, upack.Int32('f'))
+        test("null") - rw(null: java.lang.Character, "null", upack.Null)
+      }
+      test("short") {
+        test("value") - rw(
+          (25123: Short): java.lang.Short,
+          "25123", """ "25123" """,
+          upack.Int32(25123), upack.Str("25123")
+        )
+        test("null") - rw(null: java.lang.Short, "null", upack.Null)
+      }
+      test("int"){
+        test("value") - rw(1: java.lang.Integer, "1", """ "1" """, upack.Int32(1), upack.Str("1"))
+        test("null") - rw(null: java.lang.Integer, "null", upack.Null)
+      }
+
+      test("long") {
+        test("value") - rw(1: java.lang.Long, "1", """ "1" """, upack.Int64(1), upack.Str("1"))
+        test("null") - rw(null: java.lang.Long, "null", upack.Null)
+      }
+
+      test("float") {
+        test("value") - rw(
+          125.125f: java.lang.Float,
+          """125.125""", """ "125.125" """,
+          upack.Float32(125.125f), upack.Str("125.125")
+        )
+        test("null") - rw(null: java.lang.Float, "null", upack.Null)
+      }
+      test("double"){
+        test("value") - rw(
+          125123: java.lang.Double,
+          """125123""", """125123.0""",
+          upack.Float64(125123), upack.Str("125123.0")
+        )
+        test("null") - rw(null: java.lang.Double, "null", upack.Null)
+      }
+    }
   }
 }

--- a/upickleReadme/Readme.scalatex
+++ b/upickleReadme/Readme.scalatex
@@ -916,6 +916,9 @@
 
         @li
           Various library dependency updates
+        @li
+          Added readers and writers for the @hl.scala("java.lang") boxed versions
+          of primitive types @lnk("#462", "https://github.com/com-lihaoyi/upickle/pull/462")
 
     @sect{2.0.0}
       @ul

--- a/upickleReadme/Readme.scalatex
+++ b/upickleReadme/Readme.scalatex
@@ -886,20 +886,24 @@
       JSON library, and inherits a lot of it's performance from Erik's work.
 
   @sect{Version History}
-    @sect{3.0.0-M2}
+    @sect{3.0.0}
       @ul
         @li
-          Greatly improved speed and runtime-time safety for Scala 3 macros
+          Greatly improved speed and runtime-time safety for Scala 3 macros.
+          These were previously much slower than Scala 2, and are now of roughly
+          identical performance @lnk("#445", "https://github.com/com-lihaoyi/upickle/pull/445")
 
         @li
           Fixed infinite compile-loop issue on Scala 3
 
         @li
-          Ensured, that @code{ujson.Value}s behave properly as a direct target of reading
-          and writing operations
+          Support for the @hl.scala{deriving} keyword in Scala 3, on both @hl.scala{enum}s
+          and @hl.scala{sealed trait}s @lnk("#453", "https://github.com/com-lihaoyi/upickle/pull/453")
 
-    @sect{3.0.0-M1}
-      @ul
+        @li
+          Ensured, that @code{ujson.Value}s behave properly as a direct target of reading
+          and writing operations @lnk("#436", "https://github.com/com-lihaoyi/upickle/pull/436")
+
         @li
           @b{Updated geny dependency from 0.7.1 to 1.0.0. This breaks binary compatibility, hence we increased the major version number.}
 
@@ -907,7 +911,11 @@
           uPickle now applies Semantic Versioning and follows the SemVer spec
 
         @li
-          various library dependency updates
+          @hl.scala{ujson.Bool} pattern matching is now exhaustive
+          @lnk("#461", "https://github.com/com-lihaoyi/upickle/pull/461")
+
+        @li
+          Various library dependency updates
 
     @sect{2.0.0}
       @ul

--- a/upickleReadme/Readme.scalatex
+++ b/upickleReadme/Readme.scalatex
@@ -886,24 +886,20 @@
       JSON library, and inherits a lot of it's performance from Erik's work.
 
   @sect{Version History}
-    @sect{3.0.0}
+    @sect{3.0.0-M2}
       @ul
         @li
-          Greatly improved speed and runtime-time safety for Scala 3 macros.
-          These were previously much slower than Scala 2, and are now of roughly
-          identical performance @lnk("#445", "https://github.com/com-lihaoyi/upickle/pull/445")
+          Greatly improved speed and runtime-time safety for Scala 3 macros
 
         @li
           Fixed infinite compile-loop issue on Scala 3
 
         @li
-          Support for the @hl.scala{deriving} keyword in Scala 3, on both @hl.scala{enum}s
-          and @hl.scala{sealed trait}s @lnk("#453", "https://github.com/com-lihaoyi/upickle/pull/453")
-
-        @li
           Ensured, that @code{ujson.Value}s behave properly as a direct target of reading
-          and writing operations @lnk("#436", "https://github.com/com-lihaoyi/upickle/pull/436")
+          and writing operations
 
+    @sect{3.0.0-M1}
+      @ul
         @li
           @b{Updated geny dependency from 0.7.1 to 1.0.0. This breaks binary compatibility, hence we increased the major version number.}
 
@@ -911,14 +907,7 @@
           uPickle now applies Semantic Versioning and follows the SemVer spec
 
         @li
-          @hl.scala{ujson.Bool} pattern matching is now exhaustive
-          @lnk("#461", "https://github.com/com-lihaoyi/upickle/pull/461")
-
-        @li
-          Various library dependency updates
-        @li
-          Added readers and writers for the @hl.scala("java.lang") boxed versions
-          of primitive types @lnk("#462", "https://github.com/com-lihaoyi/upickle/pull/462")
+          various library dependency updates
 
     @sect{2.0.0}
       @ul


### PR DESCRIPTION
The current readers and writers already handle `null` correctly:

1. Readers https://github.com/com-lihaoyi/upickle/blob/7e469da3c721872e482a505cd71119537b2a2f20/core/src/upickle/core/SimpleVisitor.scala#L9
2. Writers https://github.com/com-lihaoyi/upickle/blob/7e469da3c721872e482a505cd71119537b2a2f20/core/src/upickle/core/Types.scala#L129

except readers cast it to e.g. `0: Int` when returning it. By casting the readers to `Reader[java.lang.Integer]`, this allows the `null`s to remain `null`s. 