### PR TITLE
Use UTF8 when reading json/msgpack bytes 

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -328,6 +328,11 @@ object ujson extends Module{
     object test extends Tests with CommonTestModule{
       override def moduleDeps = super.moduleDeps ++ Seq(core.jvm().test)
     }
+    object testNonUtf8 extends Tests with CommonTestModule{
+      override def moduleDeps = super.moduleDeps ++ Seq(core.jvm().test)
+
+      override def forkArgs = T{ Seq("-Dfile.encoding=US-ASCII") }
+    }
   }
 
   object native extends Cross[NativeModule](scalaNativeVersions:_*)

--- a/build.sc
+++ b/build.sc
@@ -328,11 +328,6 @@ object ujson extends Module{
     object test extends Tests with CommonTestModule{
       override def moduleDeps = super.moduleDeps ++ Seq(core.jvm().test)
     }
-    object testNonUtf8 extends Tests with CommonTestModule{
-      override def moduleDeps = super.moduleDeps ++ Seq(core.jvm().test)
-
-      override def forkArgs = T{ Seq("-Dfile.encoding=US-ASCII") }
-    }
   }
 
   object native extends Cross[NativeModule](scalaNativeVersions:_*)
@@ -413,6 +408,12 @@ object upickle extends Module{
       override def scalacOptions = super.scalacOptions() ++ {
         if (isDotty) Seq("-Ximport-suggestion-timeout", "0")
         else Nil
+      }
+    }
+
+    object testNonUtf8 extends Tests with CommonTestModule {
+      override def forkArgs = T {
+        Seq("-Dfile.encoding=US-ASCII")
       }
     }
   }

--- a/core/src/upickle/core/ElemOps.scala
+++ b/core/src/upickle/core/ElemOps.scala
@@ -1,5 +1,5 @@
-
 package upickle.core
+import java.nio.charset.StandardCharsets
 
 object CharOps {
   def toInt(c: Char) = c.toInt
@@ -7,6 +7,7 @@ object CharOps {
   def lessThan(c1: Char, c2: Char) = c1 < c2
   def within(c1: Char, c2: Char, c3: Char) = c1 <= c2 && c2 <= c3
   type Output = java.io.Writer
+  def newString(arr: Array[Char], i: Int, length: Int) = new String(arr, i, length)
 
 }
 object ByteOps {
@@ -15,4 +16,5 @@ object ByteOps {
   def lessThan(c1: Byte, c2: Char) = c1 < c2
   def within(c1: Char, c2: Byte, c3: Char) = c1 <= c2 && c2 <= c3
   type Output = java.io.OutputStream
+  def newString(arr: Array[Byte], i: Int, length: Int) = new String(arr, i, length, StandardCharsets.UTF_8)
 }

--- a/core/templates/BufferingElemParser.scala
+++ b/core/templates/BufferingElemParser.scala
@@ -63,7 +63,7 @@ trait BufferingElemParser{
 
   def sliceString(i: Int, k: Int): String = {
     requestUntil(k - 1)
-    new String(buffer, i - firstIdx, k - i)
+    ElemOps.newString(buffer, i - firstIdx, k - i)
   }
 
   def sliceArr(i: Int, n: Int): (Array[Elem], Int, Int) = {

--- a/core/templates/ElemBuilder.scala
+++ b/core/templates/ElemBuilder.scala
@@ -50,7 +50,7 @@ class ElemBuilder(startSize: Int = 32) extends upickle.core.ElemAppendC{
     length += 1
   }
 
-  def makeString(): String = new String(arr, 0, length)
+  def makeString(): String = ElemOps.newString(arr, 0, length)
   def writeOutToIfLongerThan(writer: upickle.core.ElemOps.Output, threshold: Int): Unit = {
     if (length > threshold) {
       writer.write(arr, 0, length)

--- a/core/templates/WrapElemArrayCharSeq.scala
+++ b/core/templates/WrapElemArrayCharSeq.scala
@@ -26,7 +26,7 @@ class WrapElemArrayCharSeq(arr: Array[Elem], start: Int, length0: Int) extends C
   override def toString = {
     if (toString0 != null) toString0
     else {
-      val res = new String(arr, start, length0)
+      val res = ElemOps.newString(arr, start, length0)
       toString0 = res
       res
     }

--- a/ujson/testNonUtf8/src/ujson/NonUtf8Tests.scala
+++ b/ujson/testNonUtf8/src/ujson/NonUtf8Tests.scala
@@ -1,0 +1,13 @@
+package ujson
+import utest._
+object NonUtf8Tests extends TestSuite {
+  def tests = Tests{
+
+    test("nonUtf8") {
+      val utf8Bytes = Array[Byte](34, -48, -65, -47, -128, -48, -72, -48, -78, -48, -75, -47, -126, 34)
+      val utf8String = ujson.Str("привет")
+      ujson.read(utf8Bytes) ==> utf8String
+      ujson.writeToByteArray(utf8String) ==> utf8Bytes
+    }
+  }
+}

--- a/upickle/testNonUtf8/src/ujson/NonUtf8Tests.scala
+++ b/upickle/testNonUtf8/src/ujson/NonUtf8Tests.scala
@@ -3,11 +3,17 @@ import utest._
 object NonUtf8Tests extends TestSuite {
   def tests = Tests{
 
-    test("nonUtf8") {
+    test("json") {
       val utf8Bytes = Array[Byte](34, -48, -65, -47, -128, -48, -72, -48, -78, -48, -75, -47, -126, 34)
       val utf8String = ujson.Str("привет")
       ujson.read(utf8Bytes) ==> utf8String
       ujson.writeToByteArray(utf8String) ==> utf8Bytes
+    }
+    test("msgpack") {
+      val utf8String = upack.Str("привет")
+      val utf8Bytes = Array[Byte](-84, -48, -65, -47, -128, -48, -72, -48, -78, -48, -75, -47, -126)
+      upack.read(utf8Bytes) ==> utf8String
+      upack.writeToByteArray(utf8String) ==> utf8Bytes
     }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/upickle/issues/413

We already hard-code support for UTF-8 when rendering JSON and MessagePack https://github.com/com-lihaoyi/upickle/blob/6e2d5713bf745094207ad6ab6ac2b824a28a229c/core/src/upickle/core/RenderUtils.scala#L28 https://github.com/com-lihaoyi/upickle/blob/6e2d5713bf745094207ad6ab6ac2b824a28a229c/upack/src/upack/MsgPackWriter.scala#L166, so the only thing missing is to ensure we use UTF-8 when reading

Added some simple tests under `upickle.jvm[_].testNonUtf8` running with `-Dfile.encoding=US-ASCII` exercise these code paths