### PR TITLE
Use a `NotGiven` implicit to avoid infinite loops caused by superTypeWriter/superTypeReader

### DIFF
--- a/core/src/upickle/core/Types.scala
+++ b/core/src/upickle/core/Types.scala
@@ -235,6 +235,13 @@ trait Types{ types =>
 }
 
 /**
+ * Implicit to indicate that we are currently deriving an implicit [[T]]. Used
+ * to avoid the implicit being derived from picking up its own definition,
+ * resulting in infinite looping/recursion
+ */
+class CurrentlyDeriving[T]
+
+/**
  * Wrap a CaseClassReader or CaseClassWriter reader/writer to handle $type tags during reading and writing.
  *
  * Note that Scala 3 singleton `enum` values do not have proper `ClassTag[V]`s

--- a/implicits/src-3/upickle/implicits/Writers.scala
+++ b/implicits/src-3/upickle/implicits/Writers.scala
@@ -4,7 +4,8 @@ import upickle.core.Annotator
 
 import deriving.Mirror
 import scala.reflect.ClassTag
-import upickle.core.{Annotator, ObjVisitor, Visitor}
+import scala.util.NotGiven
+import upickle.core.{Annotator, ObjVisitor, Visitor, CurrentlyDeriving}
 
 trait WritersVersionSpecific
   extends MacrosCommon
@@ -49,6 +50,7 @@ trait WritersVersionSpecific
       else writer
 
     case _: Mirror.SumOf[T] =>
+      implicit val currentlyDeriving: upickle.core.CurrentlyDeriving[T] = new upickle.core.CurrentlyDeriving()
       val writers: List[Writer[_ <: T]] = compiletime.summonAll[Tuple.Map[m.MirroredElemTypes, Writer]]
         .toList
         .asInstanceOf[List[Writer[_ <: T]]]
@@ -62,7 +64,8 @@ trait WritersVersionSpecific
       macros.defineEnumWriters[Writer[T], Tuple.Map[m.MirroredElemTypes, Writer]](this)
   }
 
-  inline given superTypeWriter[T: Mirror.ProductOf : ClassTag, V >: T : Writer]: Writer[T] = {
+  inline given superTypeWriter[T: Mirror.ProductOf : ClassTag, V >: T : Writer]
+                              (using NotGiven[CurrentlyDeriving[V]]): Writer[T] = {
     implicitly[Writer[V]].comap[T](_.asInstanceOf[V])
   }
 

--- a/implicits/src/upickle/implicits/Readers.scala
+++ b/implicits/src/upickle/implicits/Readers.scala
@@ -326,7 +326,9 @@ trait Readers extends upickle.core.Types
       }
     }
   implicit def SeqLikeReader[C[_], T](implicit r: Reader[T],
-                                      factory: Factory[T, C[T]]): Reader[C[T]] = new SimpleReader[C[T]] {
+                                      factory: Factory[T, C[T]]): Reader[C[T]] = new SeqLikeReader[C, T]()
+  class SeqLikeReader[C[_], T](implicit r: Reader[T],
+                                      factory: Factory[T, C[T]]) extends SimpleReader[C[T]] {
     override def expectedMsg = "expected sequence"
     override def visitArray(length: Int, index: Int) = new ArrVisitor[Any, C[T]] {
       val b = factory.newBuilder

--- a/upickle/test/src-3/upickle/DerivationTests.scala
+++ b/upickle/test/src-3/upickle/DerivationTests.scala
@@ -151,5 +151,15 @@ object DerivationTests extends TestSuite {
         assert(e.getMessage == "invalid tag for tagged object: upickle.Level1Cls at index 10")
       }
     }
+    test("issue468"){
+      enum A:
+        case B
+
+      val rwError = compileError("""given rw: upickle.default.ReadWriter[A] = upickle.default.macroRW""")
+      val rError = compileError("""given r: upickle.default.Reader[A] = upickle.default.macroR""")
+      val wError = compileError("""given w: upickle.default.Writer[A] = upickle.default.macroW""")
+      assert(rError.msg.contains("No given instance of type ReadersVersionSpecific_this.Reader[(A.B : A)] was found"))
+      assert(wError.msg.contains("No given instance of type WritersVersionSpecific_this.Writer[(A.B : A)] was found"))
+    }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/upickle/issues/468

The basic problem is that with `enum A: case B`, Calling `implicit def rw: RW[A] = macroR` will end up looking for a `R[B]`, which will trigger `superTypeReader[B, A]`, which picks up the `rw` we are defining and becoming an infinite recursion/loop.

The fix here is to ensure that when calling `macroR[T]`/`macroW[T]`/`macroRW[T]`, that `superTypeReader` and `superTypeWriter` do not trigger on type `[_, T]`. We can do that by requiring that they take a `NotGiven[CurrentlyDeriving[T]]`, and providing an implicit `CurrentlyDeriving[T]` in the `macroR`/`macroW`/`macroRW` bodies.

Added some `compileError` tests to ensure these raise implicit not found errors as expected

While `superTypeWriter`/`superTypeReader` had their signatures changed, the fact that they are `inline` means there are no binary compatibility concerns

This is only necessary for Scala 3, since Scala 2 doesn't have `superTypeWriter`/`superTypeReader` in the first place due to diverging implicit issues (see https://github.com/com-lihaoyi/upickle/pull/459)