### PR TITLE
Release uPickle 3.1.0

### DIFF
--- a/upickleReadme/Readme.scalatex
+++ b/upickleReadme/Readme.scalatex
@@ -25,7 +25,7 @@
   )
 )
 
-@sect("uPickle 3.0.0")
+@sect("uPickle 3.1.0")
   @div(display.flex, alignItems.center, flexDirection.column)
     @div
       @a(href := "https://gitter.im/lihaoyi/upickle")(
@@ -74,8 +74,8 @@
 
   @sect{Getting Started}
     @hl.scala
-      "com.lihaoyi" %% "upickle" % "3.0.0" // SBT
-      ivy"com.lihaoyi::upickle:3.0.0" // Mill
+      "com.lihaoyi" %% "upickle" % "3.1.0" // SBT
+      ivy"com.lihaoyi::upickle:3.1.0" // Mill
 
     @p
       And then you can immediately start writing and reading common Scala
@@ -93,8 +93,8 @@
       @p
         For ScalaJS applications, use this dependencies instead:
       @hl.scala
-        "com.lihaoyi" %%% "upickle" % "3.0.0" // SBT
-        ivy"com.lihaoyi::upickle::3.0.0" // Mill
+        "com.lihaoyi" %%% "upickle" % "3.1.0" // SBT
+        ivy"com.lihaoyi::upickle::3.1.0" // Mill
 
     @sect{Scala Versions}
       @p
@@ -886,6 +886,20 @@
       JSON library, and inherits a lot of it's performance from Erik's work.
 
   @sect{Version History}
+    @sect{3.1.0}
+      @ul
+        @li
+          Across-the-board performance optimizations @lnk("#467", "https://github.com/com-lihaoyi/upickle/pull/467")
+        @li
+          Make @hl.scala{derives} properly handle @hl.scala{abstract class}es in Scala 3
+          @lnk("#470", "https://github.com/com-lihaoyi/upickle/pull/470")
+        @li
+          Use a NotGiven implicit to avoid infinite loops caused by
+          @code{superTypeWriter}/@code{superTypeReader}
+          @lnk("#471", "https://github.com/com-lihaoyi/upickle/pull/471")
+        @li
+          Fix ClassCastException on @hl.scala{import given}
+          @lnk("#472", "https://github.com/com-lihaoyi/upickle/pull/472")
     @sect{3.0.0}
       @ul
         @li

--- a/upickleReadme/Readme.scalatex
+++ b/upickleReadme/Readme.scalatex
@@ -900,6 +900,9 @@
         @li
           Fix ClassCastException on @hl.scala{import given}
           @lnk("#472", "https://github.com/com-lihaoyi/upickle/pull/472")
+        @li
+          Added readwriters for @code{SortedMap} and @code{LinkedHashMap}
+          @lnk("#479", "https://github.com/com-lihaoyi/upickle/pull/479")
     @sect{3.0.0}
       @ul
         @li


### PR DESCRIPTION
Targeting a release end-April. Since none of the fixes are showstoppers (the bugs have workarounds, and perf improvements are always just a nice-to-have) there isn't any real urgency to push them out, and we can wait a bit to see if anyone else has changes they want to get in