### PR TITLE
Make empty arrays and dictionaries render compactly even when indent > 0

### DIFF
--- a/ujson/templates/BaseElemRenderer.scala
+++ b/ujson/templates/BaseElemRenderer.scala
@@ -28,7 +28,7 @@ class BaseElemRenderer[T <: upickle.core.ElemOps.Output]
   private[this] var visitingKey = false
 
   private[this] var commaBuffered = false
-  private[this] var newNestingBuffered = false
+  private[this] var indentBuffered = false
   private[this] var quoteBuffered = false
 
   def flushBuffer() = {
@@ -36,8 +36,8 @@ class BaseElemRenderer[T <: upickle.core.ElemOps.Output]
       commaBuffered = false
       elemBuilder.append(',')
     }
-    if (newNestingBuffered){
-      newNestingBuffered = false
+    if (indentBuffered){
+      indentBuffered = false
       renderIndent()
     }
     if (quoteBuffered) {
@@ -51,21 +51,21 @@ class BaseElemRenderer[T <: upickle.core.ElemOps.Output]
     elemBuilder.append('[')
 
     depth += 1
-    newNestingBuffered = true
+    indentBuffered = true
 
     def subVisitor = BaseElemRenderer.this
 
     def visitValue(v: T, index: Int): Unit = {
       flushBuffer()
       commaBuffered = true
-      newNestingBuffered = true
+      indentBuffered = true
     }
 
     def visitEnd(index: Int) = {
       depth -= 1
-      if (newNestingBuffered && commaBuffered) renderIndent()
+      if (indentBuffered && commaBuffered) renderIndent()
       commaBuffered = false
-      newNestingBuffered = false
+      indentBuffered = false
       elemBuilder.append(']')
       flushElemBuilder()
       out
@@ -76,7 +76,7 @@ class BaseElemRenderer[T <: upickle.core.ElemOps.Output]
     flushBuffer()
     elemBuilder.append('{')
     depth += 1
-    newNestingBuffered = true
+    indentBuffered = true
 
     def subVisitor = BaseElemRenderer.this
     def visitKey(index: Int) = {
@@ -94,14 +94,14 @@ class BaseElemRenderer[T <: upickle.core.ElemOps.Output]
 
     def visitValue(v: T, index: Int): Unit = {
       commaBuffered = true
-      newNestingBuffered = true
+      indentBuffered = true
     }
 
     def visitEnd(index: Int) = {
       depth -= 1
-      if (newNestingBuffered && commaBuffered) renderIndent()
+      if (indentBuffered && commaBuffered) renderIndent()
       commaBuffered = false
-      newNestingBuffered = false
+      indentBuffered = false
       elemBuilder.append('}')
       flushElemBuilder()
       out

--- a/upickle/test/src/upickle/example/ExampleTests.scala
+++ b/upickle/test/src/upickle/example/ExampleTests.scala
@@ -178,6 +178,7 @@ object ExampleTests extends TestSuite {
         write(Map(1 -> 2, 3 -> 4))         ==> """{"1":2,"3":4}"""
         write(Map("hello" -> "world"))     ==> """{"hello":"world"}"""
         write(Map(Seq(1, 2) -> Seq(3, 4))) ==> """[[[1,2],[3,4]]]"""
+        write(Map(Seq.empty[Int] -> Seq.empty[Int])) ==> """[[[],[]]]"""
         write(Map.empty[Int, Int])         ==> """{}"""
 
         write(Map(1 -> 2, 3 -> 4), indent = 4) ==>
@@ -185,6 +186,14 @@ object ExampleTests extends TestSuite {
           |    "1": 2,
           |    "3": 4
           |}""".stripMargin
+
+        write(Map(Seq.empty[Int] -> Seq.empty[Int]), indent = 4) ==>
+        """[
+          |    [
+          |        [],
+          |        []
+          |    ]
+          |]""".stripMargin
 
         write(Map.empty[Int, Int], indent = 4) ==> """{}"""
       }

--- a/upickle/test/src/upickle/example/ExampleTests.scala
+++ b/upickle/test/src/upickle/example/ExampleTests.scala
@@ -156,7 +156,7 @@ object ExampleTests extends TestSuite {
         write("omg")                      ==> "\"omg\""
       }
       test("seqs"){
-        write(Array.empty[Int])             ==> "[]"
+        write(Array.empty[Int])           ==> "[]"
         write(Array(1, 2, 3))             ==> "[1,2,3]"
 
         // You can pass in an `indent` parameter to format it nicely
@@ -178,8 +178,8 @@ object ExampleTests extends TestSuite {
         write(Map(1 -> 2, 3 -> 4))         ==> """{"1":2,"3":4}"""
         write(Map("hello" -> "world"))     ==> """{"hello":"world"}"""
         write(Map(Seq(1, 2) -> Seq(3, 4))) ==> """[[[1,2],[3,4]]]"""
-        write(Map(Seq.empty[Int] -> Seq.empty[Int])) ==> """[[[],[]]]"""
         write(Map.empty[Int, Int])         ==> """{}"""
+        write(Map(Seq.empty[Int] -> Seq.empty[Int])) ==> """[[[],[]]]"""
 
         write(Map(1 -> 2, 3 -> 4), indent = 4) ==>
         """{

--- a/upickle/test/src/upickle/example/ExampleTests.scala
+++ b/upickle/test/src/upickle/example/ExampleTests.scala
@@ -156,9 +156,11 @@ object ExampleTests extends TestSuite {
         write("omg")                      ==> "\"omg\""
       }
       test("seqs"){
+        write(Array.empty[Int])             ==> "[]"
         write(Array(1, 2, 3))             ==> "[1,2,3]"
 
         // You can pass in an `indent` parameter to format it nicely
+        write(Array.empty[Int], indent = 4)  ==> "[]"
         write(Array(1, 2, 3), indent = 4)  ==>
           """[
             |    1,
@@ -176,6 +178,15 @@ object ExampleTests extends TestSuite {
         write(Map(1 -> 2, 3 -> 4))         ==> """{"1":2,"3":4}"""
         write(Map("hello" -> "world"))     ==> """{"hello":"world"}"""
         write(Map(Seq(1, 2) -> Seq(3, 4))) ==> """[[[1,2],[3,4]]]"""
+        write(Map.empty[Int, Int])         ==> """{}"""
+
+        write(Map(1 -> 2, 3 -> 4), indent = 4) ==>
+        """{
+          |    "1": 2,
+          |    "3": 4
+          |}""".stripMargin
+
+        write(Map.empty[Int, Int], indent = 4) ==> """{}"""
       }
       test("options"){
         write(Some(1))                    ==> "[1]"
@@ -228,6 +239,21 @@ object ExampleTests extends TestSuite {
         write(Bar("bearrr", Seq(Foo(1), Foo(2), Foo(3)))) ==>
           """{"name":"bearrr","foos":[{"i":1},{"i":2},{"i":3}]}"""
 
+        write(Bar("bearrr", Seq(Foo(1), Foo(2), Foo(3))), indent = 4) ==>
+          """{
+            |    "name": "bearrr",
+            |    "foos": [
+            |        {
+            |            "i": 1
+            |        },
+            |        {
+            |            "i": 2
+            |        },
+            |        {
+            |            "i": 3
+            |        }
+            |    ]
+            |}""".stripMargin
       }
       test("null"){
         write(Bar(null, Seq(Foo(1), null, Foo(3)))) ==>

--- a/upickle/test/src/upickle/example/ExampleTests.scala
+++ b/upickle/test/src/upickle/example/ExampleTests.scala
@@ -247,22 +247,6 @@ object ExampleTests extends TestSuite {
 
         write(Bar("bearrr", Seq(Foo(1), Foo(2), Foo(3)))) ==>
           """{"name":"bearrr","foos":[{"i":1},{"i":2},{"i":3}]}"""
-
-        write(Bar("bearrr", Seq(Foo(1), Foo(2), Foo(3))), indent = 4) ==>
-          """{
-            |    "name": "bearrr",
-            |    "foos": [
-            |        {
-            |            "i": 1
-            |        },
-            |        {
-            |            "i": 2
-            |        },
-            |        {
-            |            "i": 3
-            |        }
-            |    ]
-            |}""".stripMargin
       }
       test("null"){
         write(Bar(null, Seq(Foo(1), null, Foo(3)))) ==>

--- a/upickle/test/src/upickle/example/ExampleTests.scala
+++ b/upickle/test/src/upickle/example/ExampleTests.scala
@@ -181,12 +181,6 @@ object ExampleTests extends TestSuite {
         write(Map.empty[Int, Int])         ==> """{}"""
         write(Map(Seq.empty[Int] -> Seq.empty[Int])) ==> """[[[],[]]]"""
 
-        write(Map(1 -> 2, 3 -> 4), indent = 4) ==>
-        """{
-          |    "1": 2,
-          |    "3": 4
-          |}""".stripMargin
-
         write(Map(Seq.empty[Int] -> Seq.empty[Int]), indent = 4) ==>
         """[
           |    [


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/upickle/issues/499

We take a similar strategy as we do for adding commas: rather than calling `renderIndent` immediately after opening a new array/dict and at `visitEnd`, we instead set an `indentBuffered` flag and defer the `renderIndent` until later. Then each `flushBuffer` call can render the indent where necessary, and `visitEnd` can perform some additional checks that the collection is not empty before rendering the final indent

Added some basic tests to `ExampleTests.scala`, since some of this behavior is probably worth showing to users in the documentation