### PR TITLE
Add `sortKeys: Boolean` flag to ujson/upickle APIs

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -26,7 +26,7 @@ val sourcecode = "0.3.0"
 val dottyCustomVersion = Option(sys.props("dottyVersion"))
 
 val scala2JVMVersions = Seq(scala212, scala213)
-val scalaVersions = scala2JVMVersions ++ Seq(scala3) ++ dottyCustomVersion
+val scalaVersions = scala2JVMVersions// ++ Seq(scala3) ++ dottyCustomVersion
 
 trait CommonPlatformModule extends ScalaModule with PlatformScalaModule{
 

--- a/ujson/src/ujson/AstTransformer.scala
+++ b/ujson/src/ujson/AstTransformer.scala
@@ -5,7 +5,7 @@ import upickle.core.compat._
 
 import scala.language.higherKinds
 
-trait AstTransformer[I] extends Transformer[I] with JsVisitor[I, I]{
+trait AstTransformer[I] extends ujson.Transformer[I] with JsVisitor[I, I]{
   def apply(t: Readable): I = t.transform(this)
 
   def transformArray[T](f: Visitor[_, T], items: Iterable[I]) = {

--- a/ujson/src/ujson/IndexedValue.scala
+++ b/ujson/src/ujson/IndexedValue.scala
@@ -10,12 +10,12 @@ import upickle.core.{Visitor, ObjVisitor, ArrVisitor, Abort, AbortException}
   * want to work with an AST but still provide source-index error positions if
   * something goes wrong
   */
-@deprecated("Left for binary compatibility, use upickle.core.BufferedValue instead")
+@deprecated("Left for binary compatibility, use upickle.core.BufferedValue instead", "After 3.1.4")
 sealed trait IndexedValue {
   def index: Int
 }
 
-@deprecated("Left for binary compatibility, use upickle.core.BufferedValue instead")
+@deprecated("Left for binary compatibility, use upickle.core.BufferedValue instead", "After 3.1.4")
 object IndexedValue extends Transformer[IndexedValue]{
   
   case class Str(index: Int, value0: java.lang.CharSequence) extends IndexedValue

--- a/ujson/src/ujson/IndexedValue.scala
+++ b/ujson/src/ujson/IndexedValue.scala
@@ -10,12 +10,12 @@ import upickle.core.{Visitor, ObjVisitor, ArrVisitor, Abort, AbortException}
   * want to work with an AST but still provide source-index error positions if
   * something goes wrong
   */
-@deprecated("Left for binary compatibility, use upickle.core.BufferedValue instead", "After 3.1.4")
+@deprecated("Left for binary compatibility, use upickle.core.BufferedValue instead", "upickle after 3.1.4")
 sealed trait IndexedValue {
   def index: Int
 }
 
-@deprecated("Left for binary compatibility, use upickle.core.BufferedValue instead", "After 3.1.4")
+@deprecated("Left for binary compatibility, use upickle.core.BufferedValue instead", "upickle after 3.1.4")
 object IndexedValue extends Transformer[IndexedValue]{
   
   case class Str(index: Int, value0: java.lang.CharSequence) extends IndexedValue

--- a/ujson/src/ujson/IndexedValue.scala
+++ b/ujson/src/ujson/IndexedValue.scala
@@ -10,10 +10,12 @@ import upickle.core.{Visitor, ObjVisitor, ArrVisitor, Abort, AbortException}
   * want to work with an AST but still provide source-index error positions if
   * something goes wrong
   */
+@Deprecated("Left for binary compatibility, use upickle.core.BufferedValue instead")
 sealed trait IndexedValue {
   def index: Int
 }
 
+@Deprecated("Left for binary compatibility, use upickle.core.BufferedValue instead")
 object IndexedValue extends Transformer[IndexedValue]{
   
   case class Str(index: Int, value0: java.lang.CharSequence) extends IndexedValue

--- a/ujson/src/ujson/IndexedValue.scala
+++ b/ujson/src/ujson/IndexedValue.scala
@@ -10,12 +10,12 @@ import upickle.core.{Visitor, ObjVisitor, ArrVisitor, Abort, AbortException}
   * want to work with an AST but still provide source-index error positions if
   * something goes wrong
   */
-@Deprecated("Left for binary compatibility, use upickle.core.BufferedValue instead")
+@deprecated("Left for binary compatibility, use upickle.core.BufferedValue instead")
 sealed trait IndexedValue {
   def index: Int
 }
 
-@Deprecated("Left for binary compatibility, use upickle.core.BufferedValue instead")
+@deprecated("Left for binary compatibility, use upickle.core.BufferedValue instead")
 object IndexedValue extends Transformer[IndexedValue]{
   
   case class Str(index: Int, value0: java.lang.CharSequence) extends IndexedValue

--- a/ujson/src/ujson/Readable.scala
+++ b/ujson/src/ujson/Readable.scala
@@ -10,7 +10,10 @@ trait Readable {
   def transform[T](f: Visitor[_, T]): T
 }
 
-object Readable extends ReadableLowPri{
+object Readable extends ReadableLowPri with Transformer[Readable]{
+  def transform[T](j: ujson.Readable, f: upickle.core.Visitor[_, T]): T = {
+    j.transform(f) 
+  }
   case class fromTransformer[T](t: T, w: Transformer[T]) extends Readable{
     def transform[T](f: Visitor[_, T]): T = {
       w.transform(t, f)

--- a/ujson/src/ujson/Transformer.scala
+++ b/ujson/src/ujson/Transformer.scala
@@ -1,7 +1,6 @@
 package ujson
 import upickle.core.Visitor
 
-trait Transformer[I] {
-  def transform[T](j: I, f: Visitor[_, T]): T
+trait Transformer[I] extends upickle.core.Transformer[I]{
   def transformable[T](j: I) = Readable.fromTransformer(j, this)
 }

--- a/ujson/src/ujson/package.scala
+++ b/ujson/src/ujson/package.scala
@@ -1,8 +1,15 @@
 import upickle.core.NoOpVisitor
+import upickle.core.BufferedValue
 
 package object ujson{
-  def transform[T](t: Readable, v: upickle.core.Visitor[_, T]) = t.transform(v)
+  def transform[T](t: Readable,
+                   v: upickle.core.Visitor[_, T],
+                   sortKeys: Boolean = false): T = {
+    BufferedValue.maybeSortKeysTransform(Readable, t, sortKeys, v)
+  }
 
+  def transform[T](t: Readable,
+                   v: upickle.core.Visitor[_, T]): T = transform(t, v, sortKeys = false)
   /**
     * Read the given JSON input as a JSON struct
     */
@@ -16,10 +23,16 @@ package object ujson{
     */
   def write(t: Value.Value,
             indent: Int = -1,
-            escapeUnicode: Boolean = false): String = {
+            escapeUnicode: Boolean = false,
+            sortKeys: Boolean = false): String = {
     val writer = new java.io.StringWriter
-    writeTo(t, writer, indent, escapeUnicode)
+    writeTo(t, writer, indent, escapeUnicode, sortKeys)
     writer.toString
+  }
+  def write(t: Value.Value,
+            indent: Int,
+            escapeUnicode: Boolean): String = {
+    write(t, indent, escapeUnicode, sortKeys = false)
   }
 
   /**
@@ -28,22 +41,45 @@ package object ujson{
   def writeTo(t: Value.Value,
               out: java.io.Writer,
               indent: Int = -1,
-              escapeUnicode: Boolean = false): Unit = {
-    transform(t, Renderer(out, indent, escapeUnicode))
+              escapeUnicode: Boolean = false,
+              sortKeys: Boolean = false): Unit = {
+    transform(t, Renderer(out, indent, escapeUnicode), sortKeys)
   }
+  def writeTo(t: Value.Value,
+              out: java.io.Writer,
+              indent: Int,
+              escapeUnicode: Boolean): Unit = {
+    writeTo(t, out, indent, escapeUnicode, sortKeys=false)
+  }
+
   def writeToOutputStream(t: Value.Value,
                           out: java.io.OutputStream,
                           indent: Int = -1,
-                          escapeUnicode: Boolean = false): Unit = {
-    transform(t, new BaseByteRenderer(out, indent, escapeUnicode))
+                          escapeUnicode: Boolean = false,
+                          sortKeys: Boolean = false): Unit = {
+    transform(t, new BaseByteRenderer(out, indent, escapeUnicode), sortKeys)
+  }
+
+  def writeToOutputStream(t: Value.Value,
+                          out: java.io.OutputStream,
+                          indent: Int,
+                          escapeUnicode: Boolean): Unit = {
+    writeToOutputStream(t, out, indent, escapeUnicode, sortKeys = false)
   }
 
   def writeToByteArray(t: Value.Value,
                        indent: Int = -1,
-                       escapeUnicode: Boolean = false) = {
+                       escapeUnicode: Boolean = false,
+                       sortKeys: Boolean = false): Array[Byte] = {
     val baos = new java.io.ByteArrayOutputStream
-    writeToOutputStream(t, baos, indent, escapeUnicode)
+    writeToOutputStream(t, baos, indent, escapeUnicode, sortKeys)
     baos.toByteArray
+  }
+
+  def writeToByteArray(t: Value.Value,
+                       indent: Int,
+                       escapeUnicode: Boolean): Array[Byte] = {
+    writeToByteArray(t, indent, escapeUnicode, sortKeys = false)
   }
 
   /**
@@ -54,17 +90,35 @@ package object ujson{
     * Parse the given JSON input and write it to a string with
     * the configured formatting
     */
-  def reformat(s: Readable, indent: Int = -1, escapeUnicode: Boolean = false): String = {
+  def reformat(s: Readable,
+               indent: Int = -1,
+               escapeUnicode: Boolean = false,
+               sortKeys: Boolean = false): String = {
     val writer = new java.io.StringWriter()
-    reformatTo(s, writer, indent, escapeUnicode)
+    reformatTo(s, writer, indent, escapeUnicode, sortKeys)
     writer.toString
+  }
+  def reformat(s: Readable,
+               indent: Int,
+               escapeUnicode: Boolean): String = {
+    reformat(s, indent, escapeUnicode, sortKeys = false)
   }
   /**
     * Parse the given JSON input and write it to a string with
     * the configured formatting to the given Writer
     */
-  def reformatTo(s: Readable, out: java.io.Writer, indent: Int = -1, escapeUnicode: Boolean = false): Unit = {
-    transform(s, Renderer(out, indent, escapeUnicode))
+  def reformatTo(s: Readable,
+                 out: java.io.Writer,
+                 indent: Int = -1,
+                 escapeUnicode: Boolean = false,
+                 sortKeys: Boolean = false): Unit = {
+    transform(s, Renderer(out, indent, escapeUnicode), sortKeys)
+  }
+  def reformatTo(s: Readable,
+                 out: java.io.Writer,
+                 indent: Int,
+                 escapeUnicode: Boolean): Unit = {
+    reformatTo(s, out, indent, escapeUnicode, sortKeys = false)
   }
   /**
     * Parse the given JSON input and write it to a string with
@@ -73,15 +127,30 @@ package object ujson{
   def reformatToOutputStream(s: Readable,
                              out: java.io.OutputStream,
                              indent: Int = -1,
-                             escapeUnicode: Boolean = false): Unit = {
-    transform(s, new BaseByteRenderer(out, indent, escapeUnicode))
+                             escapeUnicode: Boolean = false,
+                             sortKeys: Boolean = false): Unit = {
+    transform(s, new BaseByteRenderer(out, indent, escapeUnicode), sortKeys)
   }
+  def reformatToOutputStream(s: Readable,
+                             out: java.io.OutputStream,
+                             indent: Int,
+                             escapeUnicode: Boolean): Unit = {
+    reformatToOutputStream(s, out, indent, escapeUnicode, sortKeys = false)
+  }
+
   def reformatToByteArray(s: Readable,
                           indent: Int = -1,
-                          escapeUnicode: Boolean = false) = {
+                          escapeUnicode: Boolean = false,
+                          sortKeys: Boolean = false): Array[Byte] = {
     val baos = new java.io.ByteArrayOutputStream
-    reformatToOutputStream(s, baos, indent, escapeUnicode)
+    reformatToOutputStream(s, baos, indent, escapeUnicode, sortKeys)
     baos.toByteArray
+  }
+
+  def reformatToByteArray(s: Readable,
+                          indent: Int,
+                          escapeUnicode: Boolean): Array[Byte] = {
+    reformatToByteArray(s, indent, escapeUnicode, sortKeys = false)
   }
   // End ujson
   @deprecated("use ujson.Value")

--- a/ujson/src/ujson/package.scala
+++ b/ujson/src/ujson/package.scala
@@ -8,6 +8,7 @@ package object ujson{
     BufferedValue.maybeSortKeysTransform(Readable, t, sortKeys, v)
   }
 
+//  @deprecated("Binary Compatibility Stub", "After 3.1.4")
   def transform[T](t: Readable,
                    v: upickle.core.Visitor[_, T]): T = transform(t, v, sortKeys = false)
   /**
@@ -29,6 +30,8 @@ package object ujson{
     writeTo(t, writer, indent, escapeUnicode, sortKeys)
     writer.toString
   }
+
+  // @deprecated("Binary Compatibility Stub", "After 3.1.4")
   def write(t: Value.Value,
             indent: Int,
             escapeUnicode: Boolean): String = {
@@ -45,11 +48,13 @@ package object ujson{
               sortKeys: Boolean = false): Unit = {
     transform(t, Renderer(out, indent, escapeUnicode), sortKeys)
   }
+
+  // @deprecated("Binary Compatibility Stub", "After 3.1.4")
   def writeTo(t: Value.Value,
               out: java.io.Writer,
               indent: Int,
               escapeUnicode: Boolean): Unit = {
-    writeTo(t, out, indent, escapeUnicode, sortKeys=false)
+    writeTo(t, out, indent, escapeUnicode, sortKeys = false)
   }
 
   def writeToOutputStream(t: Value.Value,
@@ -60,6 +65,7 @@ package object ujson{
     transform(t, new BaseByteRenderer(out, indent, escapeUnicode), sortKeys)
   }
 
+  // @deprecated("Binary Compatibility Stub", "After 3.1.4")
   def writeToOutputStream(t: Value.Value,
                           out: java.io.OutputStream,
                           indent: Int,
@@ -76,6 +82,7 @@ package object ujson{
     baos.toByteArray
   }
 
+  // @deprecated("Binary Compatibility Stub", "After 3.1.4")
   def writeToByteArray(t: Value.Value,
                        indent: Int,
                        escapeUnicode: Boolean): Array[Byte] = {
@@ -98,6 +105,8 @@ package object ujson{
     reformatTo(s, writer, indent, escapeUnicode, sortKeys)
     writer.toString
   }
+
+  // @deprecated("Binary Compatibility Stub", "After 3.1.4")
   def reformat(s: Readable,
                indent: Int,
                escapeUnicode: Boolean): String = {
@@ -114,6 +123,8 @@ package object ujson{
                  sortKeys: Boolean = false): Unit = {
     transform(s, Renderer(out, indent, escapeUnicode), sortKeys)
   }
+
+  // @deprecated("Binary Compatibility Stub", "After 3.1.4")
   def reformatTo(s: Readable,
                  out: java.io.Writer,
                  indent: Int,
@@ -131,6 +142,8 @@ package object ujson{
                              sortKeys: Boolean = false): Unit = {
     transform(s, new BaseByteRenderer(out, indent, escapeUnicode), sortKeys)
   }
+
+  // @deprecated("Binary Compatibility Stub", "After 3.1.4")
   def reformatToOutputStream(s: Readable,
                              out: java.io.OutputStream,
                              indent: Int,
@@ -147,6 +160,7 @@ package object ujson{
     baos.toByteArray
   }
 
+  // @deprecated("Binary Compatibility Stub", "After 3.1.4")
   def reformatToByteArray(s: Readable,
                           indent: Int,
                           escapeUnicode: Boolean): Array[Byte] = {

--- a/ujson/src/ujson/package.scala
+++ b/ujson/src/ujson/package.scala
@@ -8,7 +8,7 @@ package object ujson{
     BufferedValue.maybeSortKeysTransform(Readable, t, sortKeys, v)
   }
 
-//  @deprecated("Binary Compatibility Stub", "After 3.1.4")
+//  @deprecated("Binary Compatibility Stub", "upickle after 3.1.4")
   def transform[T](t: Readable,
                    v: upickle.core.Visitor[_, T]): T = transform(t, v, sortKeys = false)
   /**
@@ -31,7 +31,7 @@ package object ujson{
     writer.toString
   }
 
-  // @deprecated("Binary Compatibility Stub", "After 3.1.4")
+  // @deprecated("Binary Compatibility Stub", "upickle after 3.1.4")
   def write(t: Value.Value,
             indent: Int,
             escapeUnicode: Boolean): String = {
@@ -49,7 +49,7 @@ package object ujson{
     transform(t, Renderer(out, indent, escapeUnicode), sortKeys)
   }
 
-  // @deprecated("Binary Compatibility Stub", "After 3.1.4")
+  // @deprecated("Binary Compatibility Stub", "upickle after 3.1.4")
   def writeTo(t: Value.Value,
               out: java.io.Writer,
               indent: Int,
@@ -65,7 +65,7 @@ package object ujson{
     transform(t, new BaseByteRenderer(out, indent, escapeUnicode), sortKeys)
   }
 
-  // @deprecated("Binary Compatibility Stub", "After 3.1.4")
+  // @deprecated("Binary Compatibility Stub", "upickle after 3.1.4")
   def writeToOutputStream(t: Value.Value,
                           out: java.io.OutputStream,
                           indent: Int,
@@ -82,7 +82,7 @@ package object ujson{
     baos.toByteArray
   }
 
-  // @deprecated("Binary Compatibility Stub", "After 3.1.4")
+  // @deprecated("Binary Compatibility Stub", "upickle after 3.1.4")
   def writeToByteArray(t: Value.Value,
                        indent: Int,
                        escapeUnicode: Boolean): Array[Byte] = {
@@ -106,7 +106,7 @@ package object ujson{
     writer.toString
   }
 
-  // @deprecated("Binary Compatibility Stub", "After 3.1.4")
+  // @deprecated("Binary Compatibility Stub", "upickle after 3.1.4")
   def reformat(s: Readable,
                indent: Int,
                escapeUnicode: Boolean): String = {
@@ -124,7 +124,7 @@ package object ujson{
     transform(s, Renderer(out, indent, escapeUnicode), sortKeys)
   }
 
-  // @deprecated("Binary Compatibility Stub", "After 3.1.4")
+  // @deprecated("Binary Compatibility Stub", "upickle after 3.1.4")
   def reformatTo(s: Readable,
                  out: java.io.Writer,
                  indent: Int,
@@ -143,7 +143,7 @@ package object ujson{
     transform(s, new BaseByteRenderer(out, indent, escapeUnicode), sortKeys)
   }
 
-  // @deprecated("Binary Compatibility Stub", "After 3.1.4")
+  // @deprecated("Binary Compatibility Stub", "upickle after 3.1.4")
   def reformatToOutputStream(s: Readable,
                              out: java.io.OutputStream,
                              indent: Int,
@@ -160,7 +160,7 @@ package object ujson{
     baos.toByteArray
   }
 
-  // @deprecated("Binary Compatibility Stub", "After 3.1.4")
+  // @deprecated("Binary Compatibility Stub", "upickle after 3.1.4")
   def reformatToByteArray(s: Readable,
                           indent: Int,
                           escapeUnicode: Boolean): Array[Byte] = {

--- a/ujson/test/src/ujson/JsonTests.scala
+++ b/ujson/test/src/ujson/JsonTests.scala
@@ -114,5 +114,32 @@ object JsonTests extends TestSuite {
       reader.getBufferCopyCount() ==> 0
       reader.getBufferLength() ==> bytes.length
     }
+    test("sortKeys"){
+      val raw = """{"d": [{"c": 0, "b": 1}], "a": 2}"""
+      val sorted = """{
+                     |    "a": 2,
+                     |    "d": [
+                     |        {
+                     |            "b": 1,
+                     |            "c": 0
+                     |        }
+                     |    ]
+                     |}""".stripMargin
+      ujson.reformat(raw, indent = 4, sortKeys = true) ==> sorted
+      
+      ujson.write(ujson.read(raw), indent = 4, sortKeys = true) ==> sorted
+      
+      val baos = new java.io.ByteArrayOutputStream
+      ujson.writeToOutputStream(ujson.read(raw), baos, indent = 4, sortKeys = true)
+      baos.toString ==> sorted
+      
+      val writer = new java.io.StringWriter
+      ujson.writeTo(ujson.read(raw), writer, indent = 4, sortKeys = true)
+      writer.toString ==> sorted
+      
+      new String(ujson.writeToByteArray(ujson.read(raw), indent = 4, sortKeys = true)) ==> sorted
+      
+      new String(ujson.reformatToByteArray(raw, indent = 4, sortKeys = true)) ==> sorted
+    }
   }
 }

--- a/upickle/core/src-2.12/upickle/core/compat/SortInPlace.scala
+++ b/upickle/core/src-2.12/upickle/core/compat/SortInPlace.scala
@@ -1,0 +1,9 @@
+package upickle.core.compat
+
+object SortInPlace {
+  def apply[T, B](t: collection.mutable.ArrayBuffer[T])(f: T => B): Unit = {
+    val sorted = t.sortBy(f)
+    t.clear()
+    t.appendAll(sorted)
+  }
+}

--- a/upickle/core/src-2.12/upickle/core/compat/SortInPlace.scala
+++ b/upickle/core/src-2.12/upickle/core/compat/SortInPlace.scala
@@ -1,7 +1,7 @@
 package upickle.core.compat
 
 object SortInPlace {
-  def apply[T, B](t: collection.mutable.ArrayBuffer[T])(f: T => B): Unit = {
+  def apply[T, B: Ordering](t: collection.mutable.ArrayBuffer[T])(f: T => B): Unit = {
     val sorted = t.sortBy(f)
     t.clear()
     t.appendAll(sorted)

--- a/upickle/core/src-2.13+/upickle/core/compat/LinkedHashMapCompat.scala
+++ b/upickle/core/src-2.13+/upickle/core/compat/LinkedHashMapCompat.scala
@@ -1,7 +1,7 @@
 package upickle.core.compat
 
-import upickle.core.compat.Factory
 import upickle.core.LinkedHashMap
+import upickle.core.compat.Factory
 
 import scala.collection.mutable
 

--- a/upickle/core/src-2.13+/upickle/core/compat/SortInPlace.scala
+++ b/upickle/core/src-2.13+/upickle/core/compat/SortInPlace.scala
@@ -1,0 +1,7 @@
+package upickle.core.compat
+
+object SortInPlace {
+  def apply[T, B: scala.Ordering](t: collection.mutable.ArrayBuffer[T])(f: T => B): Unit = {
+    t.sortInPlaceBy(f)
+  }
+}

--- a/upickle/core/src/upickle/core/BufferedValue.scala
+++ b/upickle/core/src/upickle/core/BufferedValue.scala
@@ -12,12 +12,55 @@ sealed trait BufferedValue {
 }
 
 object BufferedValue extends Transformer[BufferedValue]{
-  
-  case class Str(index: Int, value0: java.lang.CharSequence) extends BufferedValue
-  case class Obj(index: Int, jsonableKeys: Boolean, value0: mutable.ArrayBuffer[(BufferedValue, BufferedValue)]) extends BufferedValue
-  case class Arr(index: Int, value: mutable.ArrayBuffer[BufferedValue]) extends BufferedValue
-  case class Num(index: Int, s: CharSequence, decIndex: Int, expIndex: Int) extends BufferedValue
-  case class NumRaw(index: Int, d: Double) extends BufferedValue
+  def valueToSortKey(b: BufferedValue): String = b match{
+    case BufferedValue.Null(i) => "00"
+    case BufferedValue.True(i) => "01" + "true"
+    case BufferedValue.False(i) => "02" + "false"
+    case BufferedValue.Str(s, i) => "03" +  s.toString
+    case BufferedValue.Num(s, _, _, i) => "04" + s.toString
+    case BufferedValue.Char(c, i) => "05" + c.toString
+    case BufferedValue.Binary(bytes, o, l, _) => "06" + new String(bytes, o, l)
+    case BufferedValue.Ext(tag, bytes, o, l, i) => "07" + tag.toString + new String(bytes, o, l)
+    case BufferedValue.Float32(f, i) => "08" + f.toString
+    case BufferedValue.Float64String(s, i) => "09" + s
+    case BufferedValue.Int32(n, i) => "10" + n.toString
+    case BufferedValue.Int64(n, i) => "11" + n.toString
+    case BufferedValue.NumRaw(d, i) => "12" + d.toString
+    case BufferedValue.UInt64(n, i) => "13" + n.toString
+    case BufferedValue.Arr(vs, i) => "14" + vs.map(valueToSortKey).mkString
+    case BufferedValue.Obj(kvs, _, i) => "15" + kvs.map{case (k, v) => valueToSortKey(k) + valueToSortKey(v)}.mkString
+  }
+
+  def maybeSortKeysTransform[T, V](tr: Transformer[T],
+                                   t: T,
+                                   sortKeys: Boolean,
+                                   f: Visitor[_, V]): V = {
+    def rec(x: BufferedValue): Unit = {
+      x match {
+        case BufferedValue.Arr(items, i) => items.map(rec)
+        case BufferedValue.Obj(items, jsonableKeys, i) =>
+          upickle.core.compat.SortInPlace[(BufferedValue, BufferedValue), String](items) {
+            case (k, v) => valueToSortKey(k)
+          }
+          items.foreach { case (c, v) => (c, rec(v)) }
+        case v =>
+      }
+    }
+
+    if (sortKeys) {
+      val buffered = tr.transform(t, BufferedValue.Builder)
+      rec(buffered)
+      BufferedValue.transform(buffered, f)
+    } else {
+      tr.transform(t, f)
+    }
+  }
+
+  case class Str(value0: java.lang.CharSequence, index: Int) extends BufferedValue
+  case class Obj(value0: mutable.ArrayBuffer[(BufferedValue, BufferedValue)], jsonableKeys: Boolean, index: Int) extends BufferedValue
+  case class Arr(value: mutable.ArrayBuffer[BufferedValue], index: Int) extends BufferedValue
+  case class Num(s: CharSequence, decIndex: Int, expIndex: Int, index: Int) extends BufferedValue
+  case class NumRaw(d: Double, index: Int) extends BufferedValue
   case class False(index: Int) extends BufferedValue{
     def value = false
   }
@@ -42,15 +85,15 @@ object BufferedValue extends Transformer[BufferedValue]{
       case BufferedValue.Null(i) => f.visitNull(i)
       case BufferedValue.True(i) => f.visitTrue(i)
       case BufferedValue.False(i) => f.visitFalse(i)
-      case BufferedValue.Str(i, s) => f.visitString(s, i)
-      case BufferedValue.Num(i, s, d, e) => f.visitFloat64StringParts(s, d, e, i)
-      case BufferedValue.NumRaw(i, d) => f.visitFloat64(d, i)
-      case BufferedValue.Arr(i, items) =>
+      case BufferedValue.Str(s, i) => f.visitString(s, i)
+      case BufferedValue.Num(s, d, e, i) => f.visitFloat64StringParts(s, d, e, i)
+      case BufferedValue.NumRaw(d, i) => f.visitFloat64(d, i)
+      case BufferedValue.Arr(items, i) =>
         val ctx = f.visitArray(items.length, i).narrow
         for(item <- items) try ctx.visitValue(transform(item, ctx.subVisitor), item.index) catch reject(item.index)
         ctx.visitEnd(i)
 
-      case BufferedValue.Obj(i, jsonableKeys, items) =>
+      case BufferedValue.Obj(items, jsonableKeys, i) =>
         val ctx = f.visitObject(items.length, jsonableKeys, i).narrow
         for((k, item) <- items) {
           val keyVisitor = try ctx.visitKey(i) catch reject(i)
@@ -79,7 +122,7 @@ object BufferedValue extends Transformer[BufferedValue]{
       def visitValue(v: BufferedValue, index: Int): Unit = {
         out.append(v)
       }
-      def visitEnd(index: Int): BufferedValue.Arr = BufferedValue.Arr(i, out)
+      def visitEnd(index: Int): BufferedValue.Arr = BufferedValue.Arr(out, i)
     }
 
     def visitObject(length: Int, jsonableKeys: Boolean, i: Int) = new ObjVisitor[BufferedValue, BufferedValue.Obj] {
@@ -91,7 +134,7 @@ object BufferedValue extends Transformer[BufferedValue]{
       def visitValue(v: BufferedValue, index: Int): Unit = {
         out.append((currentKey, v))
       }
-      def visitEnd(index: Int): BufferedValue.Obj = BufferedValue.Obj(i, jsonableKeys, out)
+      def visitEnd(index: Int): BufferedValue.Obj = BufferedValue.Obj(out, jsonableKeys, i)
     }
 
     def visitNull(i: Int) = BufferedValue.Null(i)
@@ -100,10 +143,10 @@ object BufferedValue extends Transformer[BufferedValue]{
 
     def visitTrue(i: Int) = BufferedValue.True(i)
 
-    def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, i: Int) = BufferedValue.Num(i, s, decIndex, expIndex)
-    override def visitFloat64(d: Double, i: Int) = BufferedValue.NumRaw(i, d)
+    def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, i: Int) = BufferedValue.Num(s, decIndex, expIndex, i)
+    override def visitFloat64(d: Double, i: Int) = BufferedValue.NumRaw(d, i)
 
-    def visitString(s: CharSequence, i: Int) = BufferedValue.Str(i, s)
+    def visitString(s: CharSequence, i: Int) = BufferedValue.Str(s, i)
 
     def visitBinary(bytes: Array[Byte], offset: Int, len: Int, index: Int) = BufferedValue. Binary(bytes, offset, len, index)
     def visitChar(s: scala.Char, index: Int) = BufferedValue. Char(s, index)

--- a/upickle/core/src/upickle/core/BufferedValue.scala
+++ b/upickle/core/src/upickle/core/BufferedValue.scala
@@ -1,0 +1,117 @@
+package upickle.core
+
+import upickle.core.ParseUtils.reject
+import scala.collection.mutable
+
+/**
+  * A reified version of [[Visitor]], allowing visitor method calls to be buffered up,
+  * stored somewhere, and replayed later.
+  */
+sealed trait BufferedValue {
+  def index: Int
+}
+
+object BufferedValue extends Transformer[BufferedValue]{
+  
+  case class Str(index: Int, value0: java.lang.CharSequence) extends BufferedValue
+  case class Obj(index: Int, jsonableKeys: Boolean, value0: mutable.ArrayBuffer[(BufferedValue, BufferedValue)]) extends BufferedValue
+  case class Arr(index: Int, value: mutable.ArrayBuffer[BufferedValue]) extends BufferedValue
+  case class Num(index: Int, s: CharSequence, decIndex: Int, expIndex: Int) extends BufferedValue
+  case class NumRaw(index: Int, d: Double) extends BufferedValue
+  case class False(index: Int) extends BufferedValue{
+    def value = false
+  }
+  case class True(index: Int) extends BufferedValue{
+    def value = true
+  }
+  case class Null(index: Int) extends BufferedValue{
+    def value = null
+  }
+
+  case class Binary(bytes: Array[Byte], offset: Int, len: Int, index: Int) extends BufferedValue
+  case class Char(s: scala.Char, index: Int) extends BufferedValue
+  case class Ext(tag: Byte, bytes: Array[Byte], offset: Int, len: Int, index: Int) extends BufferedValue
+  case class Float32(d: Float, index: Int) extends BufferedValue
+  case class Float64String(s: String, index: Int) extends BufferedValue
+  case class Int32(i: Int, index: Int) extends BufferedValue
+  case class Int64(i: Long, index: Int) extends BufferedValue
+  case class UInt64(i: Long, index: Int) extends BufferedValue
+
+  def transform[T](j: BufferedValue, f: Visitor[_, T]): T = try{
+    j match{
+      case BufferedValue.Null(i) => f.visitNull(i)
+      case BufferedValue.True(i) => f.visitTrue(i)
+      case BufferedValue.False(i) => f.visitFalse(i)
+      case BufferedValue.Str(i, s) => f.visitString(s, i)
+      case BufferedValue.Num(i, s, d, e) => f.visitFloat64StringParts(s, d, e, i)
+      case BufferedValue.NumRaw(i, d) => f.visitFloat64(d, i)
+      case BufferedValue.Arr(i, items) =>
+        val ctx = f.visitArray(items.length, i).narrow
+        for(item <- items) try ctx.visitValue(transform(item, ctx.subVisitor), item.index) catch reject(item.index)
+        ctx.visitEnd(i)
+
+      case BufferedValue.Obj(i, jsonableKeys, items) =>
+        val ctx = f.visitObject(items.length, jsonableKeys, i).narrow
+        for((k, item) <- items) {
+          val keyVisitor = try ctx.visitKey(i) catch reject(i)
+          val key = transform(k, keyVisitor)
+          ctx.visitKeyValue(key)
+          try ctx.visitValue(transform(item, ctx.subVisitor), item.index)
+          catch reject(item.index)
+        }
+        ctx.visitEnd(i)
+      case BufferedValue.Binary(bytes, offset, len, index) => f.visitBinary(bytes, offset, len, index)
+      case BufferedValue.Char(s, index) => f.visitChar(s, index)
+      case BufferedValue.Ext(tag, bytes, offset, len, index) => f.visitExt(tag, bytes, offset, len, index)
+      case BufferedValue.Float32(d, index) => f.visitFloat32(d, index)
+      case BufferedValue.Float64String(s, index) => f.visitFloat64String(s, index)
+      case BufferedValue.Int32(i, index) => f.visitInt32(i, index)
+      case BufferedValue.Int64(i, index) => f.visitInt64(i, index)
+      case BufferedValue.UInt64(i, index) => f.visitUInt64(i, index)
+    }
+  } catch reject(j.index)
+
+
+  object Builder extends Visitor[BufferedValue, BufferedValue]{
+    def visitArray(length: Int, i: Int) = new ArrVisitor[BufferedValue, BufferedValue.Arr] {
+      val out = mutable.ArrayBuffer.empty[BufferedValue]
+      def subVisitor = Builder
+      def visitValue(v: BufferedValue, index: Int): Unit = {
+        out.append(v)
+      }
+      def visitEnd(index: Int): BufferedValue.Arr = BufferedValue.Arr(i, out)
+    }
+
+    def visitObject(length: Int, jsonableKeys: Boolean, i: Int) = new ObjVisitor[BufferedValue, BufferedValue.Obj] {
+      val out = mutable.ArrayBuffer.empty[(BufferedValue, BufferedValue)]
+      var currentKey: BufferedValue = _
+      def subVisitor = Builder
+      def visitKey(index: Int) = BufferedValue.Builder
+      def visitKeyValue(s: Any): Unit = currentKey = s.asInstanceOf[BufferedValue]
+      def visitValue(v: BufferedValue, index: Int): Unit = {
+        out.append((currentKey, v))
+      }
+      def visitEnd(index: Int): BufferedValue.Obj = BufferedValue.Obj(i, jsonableKeys, out)
+    }
+
+    def visitNull(i: Int) = BufferedValue.Null(i)
+
+    def visitFalse(i: Int) = BufferedValue.False(i)
+
+    def visitTrue(i: Int) = BufferedValue.True(i)
+
+    def visitFloat64StringParts(s: CharSequence, decIndex: Int, expIndex: Int, i: Int) = BufferedValue.Num(i, s, decIndex, expIndex)
+    override def visitFloat64(d: Double, i: Int) = BufferedValue.NumRaw(i, d)
+
+    def visitString(s: CharSequence, i: Int) = BufferedValue.Str(i, s)
+
+    def visitBinary(bytes: Array[Byte], offset: Int, len: Int, index: Int) = BufferedValue. Binary(bytes, offset, len, index)
+    def visitChar(s: scala.Char, index: Int) = BufferedValue. Char(s, index)
+    def visitExt(tag: Byte, bytes: Array[Byte], offset: Int, len: Int, index: Int) = BufferedValue. Ext(tag, bytes, offset, len, index)
+    def visitFloat32(d: Float, index: Int) = BufferedValue. Float32(d, index)
+    def visitFloat64String(s: String, index: Int) = BufferedValue. Float64String(s, index)
+    def visitInt32(i: Int, index: Int) = BufferedValue. Int32(i, index)
+    def visitInt64(i: Long, index: Int) = BufferedValue. Int64(i, index)
+    def visitUInt64(i: Long, index: Int) = BufferedValue. UInt64(i, index)
+  }
+}

--- a/upickle/core/src/upickle/core/Transformer.scala
+++ b/upickle/core/src/upickle/core/Transformer.scala
@@ -1,0 +1,5 @@
+package upickle.core
+
+trait Transformer[I] {
+  def transform[T](j: I, f: Visitor[_, T]): T
+}

--- a/upickle/core/src/upickle/core/Types.scala
+++ b/upickle/core/src/upickle/core/Types.scala
@@ -115,7 +115,7 @@ trait Types{ types =>
     * Generally nothing more than a way of applying the [[T]] to
     * a [[Visitor]], along with some utility methods
     */
-  trait Writer[T] {
+  trait Writer[T] extends Transformer[T]{
     /**
      * Whether or not the type being written can be used as a key in a JSON dictionary.
      * Opt-in, and only applicable to writers that write primitive types like

--- a/upickle/src/upickle/Api.scala
+++ b/upickle/src/upickle/Api.scala
@@ -54,7 +54,7 @@ trait Api
     maybeSortKeysTransform(t, sortKeys, ujson.StringRenderer(indent, escapeUnicode)).toString
   }
 
-  // @deprecated("Binary Compatibility Stub", "After 3.1.4")
+  // @deprecated("Binary Compatibility Stub", "upickle after 3.1.4")
   def write[T: Writer](t: T,
                        indent: Int,
                        escapeUnicode: Boolean): String = {
@@ -69,7 +69,7 @@ trait Api
     maybeSortKeysTransform(t, sortKeys, new upack.MsgPackWriter(new ByteArrayOutputStream())).toByteArray
   }
 
-  // @deprecated("Binary Compatibility Stub", "After 3.1.4")
+  // @deprecated("Binary Compatibility Stub", "upickle after 3.1.4")
   def writeBinary[T: Writer](t: T): Array[Byte] = writeBinary(t, sortKeys = false)
 
   /**
@@ -94,7 +94,7 @@ trait Api
   }
 
 
-  // @deprecated("Binary Compatibility Stub", "After 3.1.4")
+  // @deprecated("Binary Compatibility Stub", "upickle after 3.1.4")
   def writeTo[T: Writer](t: T,
                          out: java.io.Writer,
                          indent: Int,
@@ -108,7 +108,7 @@ trait Api
     maybeSortKeysTransform(t, sortKeys, new ujson.BaseByteRenderer(out, indent = indent, escapeUnicode))
   }
 
-  // @deprecated("Binary Compatibility Stub", "After 3.1.4")
+  // @deprecated("Binary Compatibility Stub", "upickle after 3.1.4")
   def writeToOutputStream[T: Writer](t: T,
                                      out: java.io.OutputStream,
                                      indent: Int,
@@ -125,7 +125,7 @@ trait Api
     out.toByteArray
   }
 
-  // @deprecated("Binary Compatibility Stub", "After 3.1.4")
+  // @deprecated("Binary Compatibility Stub", "upickle after 3.1.4")
   def writeToByteArray[T: Writer](t: T,
                                   indent: Int,
                                   escapeUnicode: Boolean): Array[Byte] = {
@@ -144,7 +144,7 @@ trait Api
     }
   }
 
-  // @deprecated("Binary Compatibility Stub", "After 3.1.4")
+  // @deprecated("Binary Compatibility Stub", "upickle after 3.1.4")
   def stream[T: Writer](t: T,
                         indent: Int,
                         escapeUnicode: Boolean): geny.Writable = {
@@ -159,7 +159,7 @@ trait Api
     streamBinary[T](t, sortKeys = sortKeys).writeBytesTo(out)
   }
 
-  // @deprecated("Binary Compatibility Stub", "After 3.1.4")
+  // @deprecated("Binary Compatibility Stub", "upickle after 3.1.4")
   def writeBinaryTo[T: Writer](t: T,
                                out: java.io.OutputStream): Unit = {
     writeBinaryTo(t, out, sortKeys = false)
@@ -172,7 +172,7 @@ trait Api
     out.toByteArray
   }
 
-  // @deprecated("Binary Compatibility Stub", "After 3.1.4")
+  // @deprecated("Binary Compatibility Stub", "upickle after 3.1.4")
   def writeBinaryToByteArray[T: Writer](t: T): Array[Byte] = {
     writeBinaryToByteArray(t, sortKeys = false)
   }
@@ -184,7 +184,7 @@ trait Api
     def writeBytesTo(out: java.io.OutputStream) = maybeSortKeysTransform(t, sortKeys, new upack.MsgPackWriter(out))
   }
 
-  // @deprecated("Binary Compatibility Stub", "After 3.1.4")
+  // @deprecated("Binary Compatibility Stub", "upickle after 3.1.4")
   def streamBinary[T: Writer](t: T): geny.Writable = {
     streamBinary(t, sortKeys = false)
   }

--- a/upickle/src/upickle/Api.scala
+++ b/upickle/src/upickle/Api.scala
@@ -54,7 +54,7 @@ trait Api
     maybeSortKeysTransform(t, sortKeys, ujson.StringRenderer(indent, escapeUnicode)).toString
   }
 
-  // Binary Compatibility Stub
+  // @deprecated("Binary Compatibility Stub", "After 3.1.4")
   def write[T: Writer](t: T,
                        indent: Int,
                        escapeUnicode: Boolean): String = {
@@ -69,7 +69,7 @@ trait Api
     maybeSortKeysTransform(t, sortKeys, new upack.MsgPackWriter(new ByteArrayOutputStream())).toByteArray
   }
 
-  // Binary Compatibility Stub
+  // @deprecated("Binary Compatibility Stub", "After 3.1.4")
   def writeBinary[T: Writer](t: T): Array[Byte] = writeBinary(t, sortKeys = false)
 
   /**
@@ -93,7 +93,8 @@ trait Api
     maybeSortKeysTransform(t, sortKeys, new ujson.Renderer(out, indent = indent, escapeUnicode))
   }
 
-  // Binary Compatibility Stub
+
+  // @deprecated("Binary Compatibility Stub", "After 3.1.4")
   def writeTo[T: Writer](t: T,
                          out: java.io.Writer,
                          indent: Int,
@@ -107,7 +108,7 @@ trait Api
     maybeSortKeysTransform(t, sortKeys, new ujson.BaseByteRenderer(out, indent = indent, escapeUnicode))
   }
 
-  // Binary Compatibility Stub
+  // @deprecated("Binary Compatibility Stub", "After 3.1.4")
   def writeToOutputStream[T: Writer](t: T,
                                      out: java.io.OutputStream,
                                      indent: Int,
@@ -124,7 +125,7 @@ trait Api
     out.toByteArray
   }
 
-  // Binary Compatibility Stub
+  // @deprecated("Binary Compatibility Stub", "After 3.1.4")
   def writeToByteArray[T: Writer](t: T,
                                   indent: Int,
                                   escapeUnicode: Boolean): Array[Byte] = {
@@ -143,7 +144,7 @@ trait Api
     }
   }
 
-  // Binary Compatibility Stub
+  // @deprecated("Binary Compatibility Stub", "After 3.1.4")
   def stream[T: Writer](t: T,
                         indent: Int,
                         escapeUnicode: Boolean): geny.Writable = {
@@ -157,7 +158,8 @@ trait Api
                                sortKeys: Boolean = false): Unit = {
     streamBinary[T](t, sortKeys = sortKeys).writeBytesTo(out)
   }
-  // Binary Compatibility Stub
+
+  // @deprecated("Binary Compatibility Stub", "After 3.1.4")
   def writeBinaryTo[T: Writer](t: T,
                                out: java.io.OutputStream): Unit = {
     writeBinaryTo(t, out, sortKeys = false)
@@ -170,7 +172,7 @@ trait Api
     out.toByteArray
   }
 
-  // Binary Compatibility Stub
+  // @deprecated("Binary Compatibility Stub", "After 3.1.4")
   def writeBinaryToByteArray[T: Writer](t: T): Array[Byte] = {
     writeBinaryToByteArray(t, sortKeys = false)
   }
@@ -182,7 +184,7 @@ trait Api
     def writeBytesTo(out: java.io.OutputStream) = maybeSortKeysTransform(t, sortKeys, new upack.MsgPackWriter(out))
   }
 
-  // Binary Compatibility Stub
+  // @deprecated("Binary Compatibility Stub", "After 3.1.4")
   def streamBinary[T: Writer](t: T): geny.Writable = {
     streamBinary(t, sortKeys = false)
   }

--- a/upickle/test/src/upickle/StructTests.scala
+++ b/upickle/test/src/upickle/StructTests.scala
@@ -609,6 +609,36 @@ object StructTests extends TestSuite {
       test("false") - rw(ujson.Bool(false), """false""")
       test("null") - rw(ujson.Null, """null""")
     }
+    test("sortKeys") {
+      val raw = """{"d": [{"c": 0, "b": 1}], "a": []}"""
+      val sorted =
+        """{
+          |    "a": [],
+          |    "d": [
+          |        {
+          |            "b": 1,
+          |            "c": 0
+          |        }
+          |    ]
+          |}""".stripMargin
+      val struct = upickle.default.read[Map[String, Seq[Map[String, Int]]]](raw)
+
+      upickle.default.write(struct, indent = 4, sortKeys = true) ==> sorted
+
+      val baos = new java.io.ByteArrayOutputStream
+      upickle.default.writeToOutputStream(struct, baos, indent = 4, sortKeys = true)
+      baos.toString ==> sorted
+
+      val writer = new java.io.StringWriter
+      upickle.default.writeTo(struct, writer, indent = 4, sortKeys = true)
+      writer.toString ==> sorted
+
+      new String(upickle.default.writeToByteArray(struct, indent = 4, sortKeys = true)) ==> sorted
+
+      val baos2 = new java.io.ByteArrayOutputStream
+      upickle.default.stream(struct, indent = 4, sortKeys = true).writeBytesTo(baos2)
+      baos2.toString() ==> sorted
+    }
   }
 }
 

--- a/upickle/test/src/upickle/example/ExampleTests.scala
+++ b/upickle/test/src/upickle/example/ExampleTests.scala
@@ -218,6 +218,18 @@ object ExampleTests extends TestSuite {
             |        "myFieldB": ""
             |    }
             |}""".stripMargin
+        
+        write(Big(1, true, "lol", 'Z', Thing(7, "")), indent = 4, sortKeys = true) ==>
+          """{
+            |    "b": true,
+            |    "c": "Z",
+            |    "i": 1,
+            |    "str": "lol",
+            |    "t": {
+            |        "myFieldA": 7,
+            |        "myFieldB": ""
+            |    }
+            |}""".stripMargin
         }
 
 


### PR DESCRIPTION
This PR allows anyone writing JSON to pass in `sortKeys = true` to make the object keys get output in sorted order.

## Major changes:

1. Introduced a new `upickle.core.BufferedValue` type. This is a sealed trait hierarchy that can be used to capture all the method calls received by a `upickle.core.Visitor`, and re-play them later. It replaces `IndexedValue`, which has JSON-specific idiosyncracies (e.g. converting MsgPack visitor calls to their JSON equivalents) whereas `BufferedValue` precisely captures the `Visitor` method calls unchanged. `IndexedValue` is left for binary compatibility but no longer used internally, even its ordering use case of buffering up things until a `$type` tag is found has been replaced by `BufferedValue`

2. As part of the generalization from `IndexedValue` to `BufferedValue`, we now need to handle non-JSON usage patterns such as non-string-keyed objects (e.g. found in msgpack). This makes sorting these objects non-trivial, as their keys can now be arbitrary `BufferedValue`s. `BufferedValue.valueToSortKey` is a rough hack to traverse any structured keys and make them sortable.
 
3. Intercept all `transform` calls in the primary upickle/ujson APIs with `BufferedValue.maybeSortKeysTransform`. This checks the new `sortKeys` boolean flag, and if true it intercepts the visitor calls, captures them in a `BufferedValue`, recursively traverses and sorts the `BufferedValue`'s object keys, then re-plays it back out

4. Binary compatibility stubs have been added to all methods who received a new `sortKeys: Boolean = true` parameter. These stubs were not marked as `@Deprecated`, because in some cases the Scala compiler would preferentially resolve the stub over the method-with-default-value, causing spurious deprecation warnings.

## Testing

1.  Sorting functionality is covered by new `sortKeys` unit tests in uJson and uPickle, and has been added to the `TestUtil.scala` round-trip tests to ensure that all existing tests exercise the a subset of the `sortKeys = true` codepaths for JSON and MsgPack and verify that the round-tripping is still successful

## Notes

1. It took a surprising amount of code to make this work well, as it goes against uPickle's "streaming-no-intermediate-data-structures" way of doing things. `sortKeys = true` *has* to buffer up some kind of intermediate JSON AST somewhere. I would expect performance to be worse than the default zero-intermediate-datastructures visitor approach, and so optimizing the `sortKeys = true` code paths was not a priority in this PR. If anyone wants maximum performance, they can leave it as the default `sortKeys = false` 

2. The whole `Transformer`/`transform` abstraction in the codebase is kind of half-baked and unsatisfactory, but I left it mostly as is for now with only small tweaks to make things work (e.g. allowing the implementation of `BufferedValue.maybeSortKeysTransform` to live in `upickle.core`). Realistically, the whole name `Transformer` and the concept it represents probably needs to be overhauled, but that's out of scope for this PR

3. `TestUtil.scala` is getting big and messy, and I'm adding to the mess. It's probably OK to leave for now, but it could definitely use a cleanup