### PR TITLE
Improve sortKeys

### DIFF
--- a/upickle/core/src-2.12/upickle/core/compat/SortInPlace.scala
+++ b/upickle/core/src-2.12/upickle/core/compat/SortInPlace.scala
@@ -1,9 +1,24 @@
 package upickle.core.compat
 
 object SortInPlace {
-  def apply[T, B: Ordering](t: collection.mutable.ArrayBuffer[T])(f: T => B): Unit = {
+  def apply[T, B: Ordering](t: collection.mutable.ArrayBuffer[T])(f: PartialFunction[T, B]): Unit = {
     val sorted = t.sortBy(f)
     t.clear()
     t.appendAll(sorted)
+  }
+}
+
+object DistinctBy{
+  def apply[T, V](items: collection.Seq[T])(f: T => V) = {
+    val output = collection.mutable.Buffer.empty[T]
+    val seen = collection.mutable.Set.empty[V]
+    for(item <- items){
+      val key = f(item)
+      if (!seen(key)) {
+        seen.add(key)
+        output.append(item)
+      }
+    }
+    output
   }
 }

--- a/upickle/core/src-2.13+/upickle/core/compat/SortInPlace.scala
+++ b/upickle/core/src-2.13+/upickle/core/compat/SortInPlace.scala
@@ -1,7 +1,13 @@
 package upickle.core.compat
 
 object SortInPlace {
-  def apply[T, B: scala.Ordering](t: collection.mutable.ArrayBuffer[T])(f: T => B): Unit = {
+  def apply[T, B: scala.Ordering](t: collection.mutable.ArrayBuffer[T])(f: PartialFunction[T, B]): Unit = {
     t.sortInPlaceBy(f)
+  }
+}
+
+object DistinctBy{
+  def apply[T, V](items: collection.Seq[T])(f: T => V) = {
+    items.distinctBy(f)
   }
 }

--- a/upickle/test/src/upickle/StructTests.scala
+++ b/upickle/test/src/upickle/StructTests.scala
@@ -705,6 +705,24 @@ object StructTests extends TestSuite {
 
         upickle.default.write(struct, indent = 4, sortKeys = true) ==> sorted
       }
+      test("strings") {
+        // Make sure that when we treat things as Strings, they are sorted
+        // as strings, unlike the above cases where they are treated as numbers
+        val raw = """{"27.5": [{"10.5": 0, "2.5": 1}], "3.5": []}"""
+        val sorted =
+          """{
+            |    "27.5": [
+            |        {
+            |            "10.5": 0,
+            |            "2.5": 1
+            |        }
+            |    ],
+            |    "3.5": []
+            |}""".stripMargin
+        val struct = upickle.default.read[Map[String, Seq[Map[String, Int]]]](raw)
+
+        upickle.default.write(struct, indent = 4, sortKeys = true) ==> sorted
+      }
     }
   }
 }

--- a/upickle/test/src/upickle/StructTests.scala
+++ b/upickle/test/src/upickle/StructTests.scala
@@ -610,34 +610,101 @@ object StructTests extends TestSuite {
       test("null") - rw(ujson.Null, """null""")
     }
     test("sortKeys") {
-      val raw = """{"d": [{"c": 0, "b": 1}], "a": []}"""
-      val sorted =
-        """{
-          |    "a": [],
-          |    "d": [
-          |        {
-          |            "b": 1,
-          |            "c": 0
-          |        }
-          |    ]
-          |}""".stripMargin
-      val struct = upickle.default.read[Map[String, Seq[Map[String, Int]]]](raw)
+      test("streaming") {
+        val raw = """{"d": [{"c": 0, "b": 1}], "a": []}"""
+        val sorted =
+          """{
+            |    "a": [],
+            |    "d": [
+            |        {
+            |            "b": 1,
+            |            "c": 0
+            |        }
+            |    ]
+            |}""".stripMargin
+        val struct = upickle.default.read[Map[String, Seq[Map[String, Int]]]](raw)
 
-      upickle.default.write(struct, indent = 4, sortKeys = true) ==> sorted
+        upickle.default.write(struct, indent = 4, sortKeys = true) ==> sorted
 
-      val baos = new java.io.ByteArrayOutputStream
-      upickle.default.writeToOutputStream(struct, baos, indent = 4, sortKeys = true)
-      baos.toString ==> sorted
+        val baos = new java.io.ByteArrayOutputStream
+        upickle.default.writeToOutputStream(struct, baos, indent = 4, sortKeys = true)
+        baos.toString ==> sorted
 
-      val writer = new java.io.StringWriter
-      upickle.default.writeTo(struct, writer, indent = 4, sortKeys = true)
-      writer.toString ==> sorted
+        val writer = new java.io.StringWriter
+        upickle.default.writeTo(struct, writer, indent = 4, sortKeys = true)
+        writer.toString ==> sorted
 
-      new String(upickle.default.writeToByteArray(struct, indent = 4, sortKeys = true)) ==> sorted
+        new String(upickle.default.writeToByteArray(struct, indent = 4, sortKeys = true)) ==> sorted
 
-      val baos2 = new java.io.ByteArrayOutputStream
-      upickle.default.stream(struct, indent = 4, sortKeys = true).writeBytesTo(baos2)
-      baos2.toString() ==> sorted
+        val baos2 = new java.io.ByteArrayOutputStream
+        upickle.default.stream(struct, indent = 4, sortKeys = true).writeBytesTo(baos2)
+        baos2.toString() ==> sorted
+      }
+
+      test("ints") {
+        val raw = """{"27": [{"10": 0, "2": 1}], "3": []}"""
+        val sorted =
+          """{
+            |    "3": [],
+            |    "27": [
+            |        {
+            |            "2": 1,
+            |            "10": 0
+            |        }
+            |    ]
+            |}""".stripMargin
+        val struct = upickle.default.read[Map[Int, Seq[Map[Int, Int]]]](raw)
+
+        upickle.default.write(struct, indent = 4, sortKeys = true) ==> sorted
+      }
+      test("longs") {
+        val raw = """{"27": [{"10": 0, "2": 1}], "300": []}"""
+        val sorted =
+          """{
+            |    "27": [
+            |        {
+            |            "2": 1,
+            |            "10": 0
+            |        }
+            |    ],
+            |    "300": []
+            |}""".stripMargin
+        val struct = upickle.default.read[Map[Long, Seq[Map[Long, Int]]]](raw)
+
+        upickle.default.write(struct, indent = 4, sortKeys = true) ==> sorted
+      }
+      test("floats") {
+        val raw = """{"27.5": [{"10.5": 0, "2.5": 1}], "3.5": []}"""
+        val sorted =
+          """{
+            |    "3.5": [],
+            |    "27.5": [
+            |        {
+            |            "2.5": 1,
+            |            "10.5": 0
+            |        }
+            |    ]
+            |}""".stripMargin
+        val struct = upickle.default.read[Map[Float, Seq[Map[Float, Int]]]](raw)
+
+        upickle.default.write(struct, indent = 4, sortKeys = true) ==> sorted
+      }
+      test("doubles") {
+        val raw = """{"27.5": [{"10.5": 0, "2.5": 1}], "3.5": []}"""
+        val sorted =
+          """{
+            |    "3.5": [],
+            |    "27.5": [
+            |        {
+            |            "2.5": 1,
+            |            "10.5": 0
+            |        }
+            |    ]
+            |}""".stripMargin
+        val struct = upickle.default.read[Map[Double, Seq[Map[Double, Int]]]](raw)
+
+        upickle.default.write(struct, indent = 4, sortKeys = true) ==> sorted
+      }
     }
   }
 }

--- a/upickleReadme/Readme.scalatex
+++ b/upickleReadme/Readme.scalatex
@@ -25,7 +25,7 @@
   )
 )
 
-@sect("uPickle 3.1.4")
+@sect("uPickle 3.1.5")
   @div(display.flex, alignItems.center, flexDirection.column)
     @div
       @a(href := "https://gitter.im/lihaoyi/upickle")(
@@ -74,8 +74,8 @@
 
   @sect{Getting Started}
     @hl.scala
-      "com.lihaoyi" %% "upickle" % "3.1.4" // SBT
-      ivy"com.lihaoyi::upickle:3.1.4" // Mill
+      "com.lihaoyi" %% "upickle" % "3.1.5" // SBT
+      ivy"com.lihaoyi::upickle:3.1.5" // Mill
 
     @p
       And then you can immediately start writing and reading common Scala
@@ -93,8 +93,8 @@
       @p
         For ScalaJS applications, use this dependencies instead:
       @hl.scala
-        "com.lihaoyi" %%% "upickle" % "3.1.4" // SBT
-        ivy"com.lihaoyi::upickle::3.1.4" // Mill
+        "com.lihaoyi" %%% "upickle" % "3.1.5" // SBT
+        ivy"com.lihaoyi::upickle::3.1.5" // Mill
 
     @sect{Scala Versions}
       @p
@@ -886,6 +886,13 @@
       JSON library, and inherits a lot of it's performance from Erik's work.
 
   @sect{Version History}
+    @sect{3.1.5}
+      @ul
+        @li
+          Add the @code{sortKeys = true} flag that can be passed to @code{upickle.default.write}
+          or @code{ujson.write}, allowing you to ensure the generated JSON has object keys in sorted
+          order
+
     @sect{3.1.4}
       @ul
         @li


### PR DESCRIPTION
Rather than using string-based sorting all the time, instead we try to find patterns where the keys are all numbers, and sort using their numeric values instead

Covered by additional unit tests