### PR TITLE
Make tagName configurable on the upickle pickler basis

### DIFF
--- a/upickle/core/src/upickle/core/Config.scala
+++ b/upickle/core/src/upickle/core/Config.scala
@@ -2,7 +2,13 @@ package upickle.core
 
 // Common things for derivation
 trait Config {
+  /**
+   * Specifies the name of the field used to distinguish different `case class`es under
+   * a `sealed trait`. Defaults to `$type`, but can be configured globally by overriding
+   * [[tagName]], or on a per-`sealed trait` basis via the `@key` annotation
+   */
   def tagName = Annotator.defaultTagKey
+
   /**
    * Whether to use the fully-qualified name of `case class`es and `case object`s which
    * are part of `sealed trait` hierarchies when serializing them and writing their `$type`

--- a/upickle/implicits/src-2/upickle/implicits/internal/Macros.scala
+++ b/upickle/implicits/src-2/upickle/implicits/internal/Macros.scala
@@ -241,7 +241,11 @@ object Macros {
             ).decodedName.toString
           )
 
-        q"${c.prefix}.annotate($derived, $tagKey, $tagValue, $shortTagValue)"
+        val tagKeyExpr = tagKey match {
+          case Some(v) => q"$v"
+          case None => q"${c.prefix}.tagName"
+        }
+        q"${c.prefix}.annotate($derived, $tagKeyExpr, $tagValue, $shortTagValue)"
       }
     }
 

--- a/upickle/implicits/src-3/upickle/implicits/Readers.scala
+++ b/upickle/implicits/src-3/upickle/implicits/Readers.scala
@@ -78,14 +78,14 @@ trait ReadersVersionSpecific
       inline if macros.isSingleton[T] then
         annotate[T](
           SingletonReader[T](macros.getSingleton[T]),
-          macros.tagKey[T],
+          macros.tagKey[T](outerThis),
           macros.tagName[T],
           macros.shortTagName[T]
         )
       else if macros.isMemberOfSealedHierarchy[T] then
         annotate[T](
           reader,
-          macros.tagKey[T],
+          macros.tagKey[T](outerThis),
           macros.tagName[T],
           macros.shortTagName[T],
         )
@@ -97,7 +97,7 @@ trait ReadersVersionSpecific
         .toList
         .asInstanceOf[List[Reader[_ <: T]]]
 
-      Reader.merge[T](macros.tagKey[T], readers: _*)
+      Reader.merge[T](macros.tagKey[T](outerThis), readers: _*)
   }
 
   inline def macroRAll[T](using m: Mirror.Of[T]): Reader[T] = inline m match {
@@ -109,7 +109,7 @@ trait ReadersVersionSpecific
   inline given superTypeReader[T: Mirror.ProductOf, V >: T : Reader : Mirror.SumOf]
                               (using NotGiven[CurrentlyDeriving[V]]): Reader[T] = {
     val actual = implicitly[Reader[V]].asInstanceOf[TaggedReader[T]]
-    val tagKey = macros.tagKey[T]
+    val tagKey = macros.tagKey[T](outerThis)
     val tagName = macros.tagName[T]
     val shortTagName = macros.shortTagName[T]
     new TaggedReader.Leaf(tagKey, tagName, shortTagName, actual.findReader(tagName))

--- a/upickle/implicits/src-3/upickle/implicits/Writers.scala
+++ b/upickle/implicits/src-3/upickle/implicits/Writers.scala
@@ -13,7 +13,6 @@ trait WritersVersionSpecific
     with Annotator
     with CaseClassReadWriters:
 
-  val outerThis = this
   inline def macroW[T: ClassTag](using m: Mirror.Of[T]): Writer[T] = inline m match {
     case m: Mirror.ProductOf[T] =>
 
@@ -46,7 +45,7 @@ trait WritersVersionSpecific
       inline if macros.isSingleton[T] then
         annotate[T](
           SingletonWriter[T](null.asInstanceOf[T]),
-          macros.tagKey[T],
+          macros.tagKey[T](outerThis),
           macros.tagName[T],
           macros.shortTagName[T],
           Annotator.Checker.Val(macros.getSingleton[T]),
@@ -54,7 +53,7 @@ trait WritersVersionSpecific
       else if macros.isMemberOfSealedHierarchy[T] then
         annotate[T](
           writer,
-          macros.tagKey[T],
+          macros.tagKey[T](outerThis),
           macros.tagName[T],
           macros.shortTagName[T],
           Annotator.Checker.Cls(implicitly[ClassTag[T]].runtimeClass),

--- a/upickle/implicits/src/upickle/implicits/MacrosCommon.scala
+++ b/upickle/implicits/src/upickle/implicits/MacrosCommon.scala
@@ -1,6 +1,8 @@
 package upickle.implicits
 
-trait MacrosCommon extends upickle.core.Config
+trait MacrosCommon extends upickle.core.Config with upickle.core.Types{
+  val outerThis = this
+}
 
 object MacrosCommon {
   def tagKeyFromParents[P](
@@ -9,7 +11,7 @@ object MacrosCommon {
     getKey: P => Option[String],
     getName: P => String,
     fail: String => Nothing,
-  ): String =
+  ): Option[String] =
     /**
       * Valid cases are:
       *
@@ -17,8 +19,8 @@ object MacrosCommon {
       * 2. All of the parents have the same `@key` annotation
       */
     sealedParents.flatMap(getKey(_)) match {
-      case Nil => upickle.core.Annotator.defaultTagKey
-      case keys @ (key :: _) if keys.length == sealedParents.length && keys.distinct.length == 1 => key
+      case Nil => None
+      case keys @ (key :: _) if keys.length == sealedParents.length && keys.distinct.length == 1 => Some(key)
       case keys =>
         fail(
           s"Type $typeName inherits from multiple parent types with different discriminator keys:\n\n" +

--- a/upickle/test/src/upickle/MacroTests.scala
+++ b/upickle/test/src/upickle/MacroTests.scala
@@ -125,6 +125,20 @@ object UnknownKeys{
     override def allowUnknownKeys = false
   }
 }
+
+object TagName{
+  object TagNamePickler extends upickle.AttributeTagged {
+    override def tagName = "_tag"
+  }
+
+  sealed trait Foo
+  case class Bar(x: Int) extends Foo
+  case class Qux(s: String) extends Foo
+
+  implicit val barRw: TagNamePickler.ReadWriter[Bar] = TagNamePickler.macroRW
+  implicit val quxRw: TagNamePickler.ReadWriter[Qux] = TagNamePickler.macroRW
+  implicit val fooRw: TagNamePickler.ReadWriter[Foo] = TagNamePickler.macroRW
+}
 object MacroTests extends TestSuite {
 
   // Doesn't work :(
@@ -846,6 +860,15 @@ object MacroTests extends TestSuite {
         new Hierarchy.C("x", "y"),
         """{"$type": "C", "s1": "x", "s2": "y"}""",
         """{"$type": "upickle.Hierarchy.C", "s1": "x", "s2": "y"}"""
+      )
+
+    }
+
+    test("tagName"){
+      val customPicklerTest = new TestUtil(TagName.TagNamePickler)
+      customPicklerTest.rw(
+        TagName.Bar(123),
+        """{"_tag": "Bar", "x": 123}"""
       )
 
     }


### PR DESCRIPTION
This functionaly was removed in https://github.com/com-lihaoyi/upickle/pull/579 when we made it configurable via `@key`, but it's easy enough to support both config mechanisms with `@key` taking precedence but `def tagName` being used as a fallback