### PR TITLE
Rename CaseClassReadereader

### DIFF
--- a/upickle/implicits/src-3/upickle/implicits/Readers.scala
+++ b/upickle/implicits/src-3/upickle/implicits/Readers.scala
@@ -14,9 +14,7 @@ trait ReadersVersionSpecific
 
   abstract class CaseClassReader[T](paramCount: Int,
                                     missingKeyCount: Long,
-                                    allowUnknownKeys: Boolean) extends CaseClassReader[T] {
-    // Bincompat stub
-    def this(paramCount: Int, missingKeyCount: Long) = this(paramCount, missingKeyCount, true)
+                                    allowUnknownKeys: Boolean) extends CaseReader[T] {
 
     def visitors0: Product
     lazy val visitors = visitors0

--- a/upickle/implicits/src-3/upickle/implicits/Readers.scala
+++ b/upickle/implicits/src-3/upickle/implicits/Readers.scala
@@ -12,9 +12,9 @@ trait ReadersVersionSpecific
     with Annotator
     with CaseClassReadWriters:
 
-  abstract class CaseClassReadereader[T](paramCount: Int,
-                                         missingKeyCount: Long,
-                                         allowUnknownKeys: Boolean) extends CaseClassReader[T] {
+  abstract class CaseClassReader[T](paramCount: Int,
+                                    missingKeyCount: Long,
+                                    allowUnknownKeys: Boolean) extends CaseClassReader[T] {
     // Bincompat stub
     def this(paramCount: Int, missingKeyCount: Long) = this(paramCount, missingKeyCount, true)
 
@@ -63,7 +63,7 @@ trait ReadersVersionSpecific
 
   inline def macroR[T](using m: Mirror.Of[T]): Reader[T] = inline m match {
     case m: Mirror.ProductOf[T] =>
-      val reader = new CaseClassReadereader[T](
+      val reader = new CaseClassReader[T](
         macros.paramsCount[T],
         macros.checkErrorMissingKeysCount[T](),
         macros.extractIgnoreUnknownKeys[T]().headOption.getOrElse(this.allowUnknownKeys)

--- a/upickle/implicits/src-3/upickle/implicits/Readers.scala
+++ b/upickle/implicits/src-3/upickle/implicits/Readers.scala
@@ -12,10 +12,9 @@ trait ReadersVersionSpecific
     with Annotator
     with CaseClassReadWriters:
 
-  abstract class CaseClassReader[T](paramCount: Int,
-                                    missingKeyCount: Long,
-                                    allowUnknownKeys: Boolean) extends CaseReader[T] {
-
+  abstract class CaseClassReader3[T](paramCount: Int,
+                                     missingKeyCount: Long,
+                                     allowUnknownKeys: Boolean) extends CaseClassReader[T] {
     def visitors0: Product
     lazy val visitors = visitors0
     def fromProduct(p: Product): T
@@ -61,7 +60,7 @@ trait ReadersVersionSpecific
 
   inline def macroR[T](using m: Mirror.Of[T]): Reader[T] = inline m match {
     case m: Mirror.ProductOf[T] =>
-      val reader = new CaseClassReader[T](
+      val reader = new CaseClassReader3[T](
         macros.paramsCount[T],
         macros.checkErrorMissingKeysCount[T](),
         macros.extractIgnoreUnknownKeys[T]().headOption.getOrElse(this.allowUnknownKeys)

--- a/upickle/implicits/src/upickle/implicits/CaseClassReadWriters.scala
+++ b/upickle/implicits/src/upickle/implicits/CaseClassReadWriters.scala
@@ -12,7 +12,7 @@ import upickle.core.{Abort, AbortException, ArrVisitor, NoOpVisitor, ObjVisitor,
 */
 trait CaseClassReadWriters extends upickle.core.Types{
   def allowUnknownKeys: Boolean = true
-  abstract class CaseReader[V] extends SimpleReader[V] {
+  abstract class CaseClassReader[V] extends SimpleReader[V] {
     override def expectedMsg = "expected dictionary"
 
     override def visitString(s: CharSequence, index: Int) = visitObject(0, true, index).visitEnd(index)
@@ -43,7 +43,7 @@ trait CaseClassReadWriters extends upickle.core.Types{
     }
   }
 
-  class SingletonReader[T](t: T) extends CaseReader[T] {
+  class SingletonReader[T](t: T) extends CaseClassReader[T] {
     override def expectedMsg = "expected string or dictionary"
 
     override def visitString(s: CharSequence, index: Int) = t

--- a/upickle/implicits/src/upickle/implicits/CaseClassReadWriters.scala
+++ b/upickle/implicits/src/upickle/implicits/CaseClassReadWriters.scala
@@ -12,7 +12,7 @@ import upickle.core.{Abort, AbortException, ArrVisitor, NoOpVisitor, ObjVisitor,
 */
 trait CaseClassReadWriters extends upickle.core.Types{
   def allowUnknownKeys: Boolean = true
-  abstract class CaseClassReader[V] extends SimpleReader[V] {
+  abstract class CaseReader[V] extends SimpleReader[V] {
     override def expectedMsg = "expected dictionary"
 
     override def visitString(s: CharSequence, index: Int) = visitObject(0, true, index).visitEnd(index)
@@ -43,7 +43,7 @@ trait CaseClassReadWriters extends upickle.core.Types{
     }
   }
 
-  class SingletonReader[T](t: T) extends CaseClassReader[T] {
+  class SingletonReader[T](t: T) extends CaseReader[T] {
     override def expectedMsg = "expected string or dictionary"
 
     override def visitString(s: CharSequence, index: Int) = t


### PR DESCRIPTION
This was a copy-paste or find-replace screwup, now that we're breaking compat in upickle 4.x we can fix it