### PR TITLE
Remove unnecessary case from annotation classes, consolidate `allowUnknownKeys` annotation

### DIFF
--- a/upickle/core/src/upickle/core/Config.scala
+++ b/upickle/core/src/upickle/core/Config.scala
@@ -67,4 +67,11 @@ trait Config {
    * un-intuitiveness and verbosity
    */
   def optionsAsNulls: Boolean = true
+
+  /**
+   * Whether or not unknown keys when de-serializing case classes should be allowed.
+   * Defaults to `true`, but can be set to `false` to make the presence unknown keys
+   * raise an error
+   */
+  def allowUnknownKeys: Boolean = true
 }

--- a/upickle/implicits/src/upickle/implicits/CaseClassReadWriters.scala
+++ b/upickle/implicits/src/upickle/implicits/CaseClassReadWriters.scala
@@ -11,7 +11,7 @@ import upickle.core.{Abort, AbortException, ArrVisitor, NoOpVisitor, ObjVisitor,
 * package to form the public API1
 */
 trait CaseClassReadWriters extends upickle.core.Types{
-  def allowUnknownKeys: Boolean = true
+  
   abstract class CaseClassReader[V] extends SimpleReader[V] {
     override def expectedMsg = "expected dictionary"
 

--- a/upickle/implicits/src/upickle/implicits/key.scala
+++ b/upickle/implicits/src/upickle/implicits/key.scala
@@ -2,5 +2,5 @@ package upickle.implicits
 
 import scala.annotation.StaticAnnotation
 
-case class key(s: String) extends StaticAnnotation
-case class allowUnknownKeys(b: Boolean) extends StaticAnnotation
+class key(s: String) extends StaticAnnotation
+class allowUnknownKeys(b: Boolean) extends StaticAnnotation


### PR DESCRIPTION
Binary incompatible, needs to be done in 4.x