### PR TITLE
Respect `Config#tagName` in `Reader.merge` and `ReadWriter.merge`

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -282,7 +282,7 @@ object upickle extends Module{
          * Auto-generated picklers and unpicklers, used for creating the 22
          * versions of tuple-picklers and case-class picklers
          */
-        trait Generated extends TupleReadWriters{
+        trait Generated extends TupleReadWriters { self: upickle.core.Config =>
           ${tuples.mkString("\n")}
         }
       """)

--- a/build.sc
+++ b/build.sc
@@ -46,19 +46,11 @@ trait CommonPublishModule
 
   def publishVersion = VcsVersion.vcsState().format()
   def mimaReportBinaryIssues() =
-    if (true || this.isInstanceOf[ScalaNativeModule] || this.isInstanceOf[ScalaJSModule]) T.command()
+    if (this.isInstanceOf[ScalaNativeModule] || this.isInstanceOf[ScalaJSModule]) T.command()
     else super.mimaReportBinaryIssues()
 
   def mimaPreviousVersions = Seq(
-    "3.0.0",
-    "3.1.0",
-    "3.1.1",
-    "3.1.2",
-    "3.1.3",
-    "3.1.4",
-    "3.2.0",
-    "3.3.0",
-    "3.3.1",
+    "4.0.0",
   )
   def isDotty = crossScalaVersion.startsWith("0") || crossScalaVersion.startsWith("3")
   def pomSettings = PomSettings(

--- a/upickle/core/src/upickle/core/Types.scala
+++ b/upickle/core/src/upickle/core/Types.scala
@@ -9,7 +9,7 @@ import scala.reflect.ClassTag
 * other internal files can use it, while also mixing it into the `upickle`
 * package to form the public API1
 */
-trait Types{ types =>
+trait Types { types: Config =>
 
   /**
     * A combined [[Reader]] and [[Writer]], along with some utility methods.
@@ -39,7 +39,7 @@ trait Types{ types =>
       new TaggedReadWriter.Node(tagKey, rws.asInstanceOf[Seq[TaggedReadWriter[T]]]:_*)
     }
 
-    def merge[T](rws: ReadWriter[_ <: T]*): TaggedReadWriter[T] = merge(Annotator.defaultTagKey, rws:_*)
+    def merge[T](rws: ReadWriter[_ <: T]*): TaggedReadWriter[T] = merge(tagName, rws:_*)
 
     implicit def join[T](implicit r0: Reader[T], w0: Writer[T]): ReadWriter[T] = (r0, w0) match{
       // Make sure we preserve the tagged-ness of the Readers/Writers being
@@ -119,7 +119,7 @@ trait Types{ types =>
       new TaggedReader.Node(tagKey, readers0.asInstanceOf[Seq[TaggedReader[T]]]:_*)
     }
 
-    def merge[T](readers0: Reader[_ <: T]*): TaggedReader.Node[T] = merge(Annotator.defaultTagKey, readers0:_*)
+    def merge[T](readers0: Reader[_ <: T]*): TaggedReader.Node[T] = merge(tagName, readers0:_*)
   }
 
   /**
@@ -164,7 +164,7 @@ trait Types{ types =>
   }
 
   trait TaggedReader[T] extends SimpleReader[T]{
-    private[upickle] def tagKey: String = Annotator.defaultTagKey
+    private[upickle] def tagKey: String = tagName
 
     def findReader(s: String): Reader[T]
 

--- a/upickle/implicits/src/upickle/implicits/CaseClassReadWriters.scala
+++ b/upickle/implicits/src/upickle/implicits/CaseClassReadWriters.scala
@@ -3,14 +3,14 @@ package upickle.implicits
 import scala.language.experimental.macros
 import scala.language.higherKinds
 import scala.reflect.ClassTag
-import upickle.core.{Abort, AbortException, ArrVisitor, NoOpVisitor, ObjVisitor, Visitor}
+import upickle.core.{Abort, AbortException, ArrVisitor, Config, NoOpVisitor, ObjVisitor, Visitor}
 
 /**
 * Basic functionality to be able to read and write objects. Kept as a trait so
 * other internal files can use it, while also mixing it into the `upickle`
 * package to form the public API1
 */
-trait CaseClassReadWriters extends upickle.core.Types{
+trait CaseClassReadWriters extends upickle.core.Types { self: Config =>
   abstract class CaseClassReader[V] extends SimpleReader[V] {
     override def expectedMsg = "expected dictionary"
 

--- a/upickle/implicits/src/upickle/implicits/TupleReadWriters.scala
+++ b/upickle/implicits/src/upickle/implicits/TupleReadWriters.scala
@@ -3,14 +3,14 @@ package upickle.implicits
 import scala.language.experimental.macros
 import scala.language.higherKinds
 import scala.reflect.ClassTag
-import upickle.core.{Visitor, Abort, ArrVisitor, ObjVisitor, NoOpVisitor}
+import upickle.core.{Visitor, Abort, ArrVisitor, Config, ObjVisitor, NoOpVisitor}
 
 /**
 * Basic functionality to be able to read and write objects. Kept as a trait so
 * other internal files can use it, while also mixing it into the `upickle`
 * package to form the public API1
 */
-trait TupleReadWriters extends upickle.core.Types{
+trait TupleReadWriters extends upickle.core.Types { self: Config =>
 
 
   class TupleNWriter[V](val writers: Array[Writer[_]], val f: V => Array[Any]) extends Writer[V]{

--- a/upickle/implicits/src/upickle/implicits/Writers.scala
+++ b/upickle/implicits/src/upickle/implicits/Writers.scala
@@ -2,7 +2,7 @@ package upickle.implicits
 
 import java.util.UUID
 
-import upickle.core.{ Visitor, Annotator }
+import upickle.core.{ Config, Visitor, Annotator }
 
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.language.higherKinds
@@ -240,7 +240,7 @@ trait Writers extends upickle.core.Types
 /**
   * This needs to be split into a separate trait due to https://github.com/scala/bug/issues/11768
   */
-trait LowPriWriters extends upickle.core.Types{
+trait LowPriWriters extends upickle.core.Types { self: Config =>
   implicit def SeqLikeWriter[C[_] <: Iterable[_], T](implicit r: Writer[T]): Writer[C[T]] = new Writer[C[T]] {
     def write0[R](out: Visitor[_, R], v: C[T]): R = {
       val ctx = out.visitArray(v.size, -1).narrow

--- a/upickle/src-js/upickle/WebJson.scala
+++ b/upickle/src-js/upickle/WebJson.scala
@@ -2,7 +2,7 @@ package upickle
 
 import scala.scalajs.js
 
-trait WebJson extends upickle.core.Types {
+trait WebJson extends upickle.core.Types { self: upickle.core.Config =>
   object web {
     def read[T: Reader](s: String) = {
       ujson.WebJson.transform(js.JSON.parse(s), implicitly[Reader[T]])

--- a/upickle/src-jvm/upickle/WebJson.scala
+++ b/upickle/src-jvm/upickle/WebJson.scala
@@ -1,6 +1,6 @@
 package upickle
 
 
-trait WebJson extends upickle.core.Types {
+trait WebJson extends upickle.core.Types { self: upickle.core.Config =>
 
 }

--- a/upickle/src-native/upickle/WebJson.scala
+++ b/upickle/src-native/upickle/WebJson.scala
@@ -1,5 +1,5 @@
 package upickle
 
-trait WebJson extends upickle.core.Types {
+trait WebJson extends upickle.core.Types { self: upickle.core.Config =>
 
 }


### PR DESCRIPTION
Follow up to #579

The `Reader.merge` and `ReadWriter.merge` methods that don't take a `tagKey` param were retained for binary compatibility and updated to pass `Annotator.defaultTagKey` to the corresponding variant that does take a `tagKey`.

This updates them to instead respect `Config#tagName`, which defaults to `Annotator.defaultTagKey` but may be overridden by downstream users.

I also re-enabled mima checks and updated `mimaPreviousVersions` to just be `4.0.0`, but I'm happy to back out those changes if they're not desirable.