### PR TITLE
Fix Readme.scalatex

### DIFF
--- a/upickleReadme/Readme.scalatex
+++ b/upickleReadme/Readme.scalatex
@@ -918,7 +918,7 @@
     @sect{4.0.1}
       @ul
         @li
-          Respect @{Config#tagName} in @code{Reader.merge} and @code{ReadWriter.merge} @lnk("#619", "https://github.com/com-lihaoyi/upickle/pull/619")
+          Respect @code{Config#tagName} in @code{Reader.merge} and @code{ReadWriter.merge} @lnk("#619", "https://github.com/com-lihaoyi/upickle/pull/619")
     @sect{4.0.0}
       @ul
         @li


### PR DESCRIPTION
There is a compile error in the documentation generation code.
Because of that I believe documentation was not updated after the last release.