### PR TITLE
Fix macro crash when handling sealed case classes

### DIFF
--- a/upickle/implicits/src-2/upickle/implicits/internal/Macros.scala
+++ b/upickle/implicits/src-2/upickle/implicits/internal/Macros.scala
@@ -219,9 +219,9 @@ object Macros {
           fail(tpe, _),
         )
 
-        val myself: Option[Symbol] = sealedParents.find(_ == tpe.typeSymbol)
+        val sealedClassSymbol: Option[Symbol] = sealedParents.find(_ == tpe.typeSymbol)
         val segments =
-          myself.toList.map(_.fullName.split('.')) ++
+          sealedClassSymbol.toList.map(_.fullName.split('.')) ++
             sealedParents
             .flatMap(_.asClass.knownDirectSubclasses)
             .map(_.fullName.split('.'))

--- a/upickle/implicits/src-2/upickle/implicits/internal/Macros.scala
+++ b/upickle/implicits/src-2/upickle/implicits/internal/Macros.scala
@@ -219,11 +219,13 @@ object Macros {
           fail(tpe, _),
         )
 
-
+        val myself: Option[Symbol] = sealedParents.find(_ == tpe.typeSymbol)
         val segments =
-          sealedParents
+          myself.toList.map(_.fullName.split('.')) ++
+            sealedParents
             .flatMap(_.asClass.knownDirectSubclasses)
             .map(_.fullName.split('.'))
+
 
         // -1 because even if there is only one subclass, and so no name segments
         // are needed to differentiate between them, we want to keep at least

--- a/upickle/implicits/src-3/upickle/implicits/macros.scala
+++ b/upickle/implicits/src-3/upickle/implicits/macros.scala
@@ -309,12 +309,15 @@ def tagNameImpl0[T](transform: String => String)(using Quotes, Type[T]): Expr[St
 inline def shortTagName[T]: String = ${ shortTagNameImpl[T] }
 def shortTagNameImpl[T](using Quotes, Type[T]): Expr[String] =
   import quotes.reflect._
-  val sym = TypeTree.of[T].symbol
+  val myself = if (TypeRepr.of[T].baseClasses.contains(TypeRepr.of[T].typeSymbol))
+    Some(TypeRepr.of[T].typeSymbol.fullName.split('.'))
+  else None
   val segments = TypeRepr.of[T].baseClasses
     .filter(_.flags.is(Flags.Sealed))
     .flatMap(_.children)
     .filter(_.flags.is(Flags.Case))
-    .map(_.fullName.split('.'))
+    .map(_.fullName.split('.')) ++
+    myself.toList
 
   val identicalSegmentCount = Range(0, segments.map(_.length).max - 1)
     .takeWhile(i => segments.map(_.lift(i)).distinct.size == 1)

--- a/upickle/implicits/src-3/upickle/implicits/macros.scala
+++ b/upickle/implicits/src-3/upickle/implicits/macros.scala
@@ -309,7 +309,7 @@ def tagNameImpl0[T](transform: String => String)(using Quotes, Type[T]): Expr[St
 inline def shortTagName[T]: String = ${ shortTagNameImpl[T] }
 def shortTagNameImpl[T](using Quotes, Type[T]): Expr[String] =
   import quotes.reflect._
-  val myself = if (TypeRepr.of[T].baseClasses.contains(TypeRepr.of[T].typeSymbol))
+  val sealedClassSymbol = if (TypeRepr.of[T].baseClasses.contains(TypeRepr.of[T].typeSymbol))
     Some(TypeRepr.of[T].typeSymbol.fullName.split('.'))
   else None
   val segments = TypeRepr.of[T].baseClasses
@@ -317,7 +317,7 @@ def shortTagNameImpl[T](using Quotes, Type[T]): Expr[String] =
     .flatMap(_.children)
     .filter(_.flags.is(Flags.Case))
     .map(_.fullName.split('.')) ++
-    myself.toList
+    sealedClassSymbol.toList
 
   val identicalSegmentCount = Range(0, segments.map(_.length).max - 1)
     .takeWhile(i => segments.map(_.lift(i)).distinct.size == 1)

--- a/upickle/test/src/upickle/MacroTests.scala
+++ b/upickle/test/src/upickle/MacroTests.scala
@@ -6,6 +6,11 @@ import upickle.default.{read, write, ReadWriter => RW}
 
 case class Trivial(a: Int = 1)
 
+sealed case class SealedClass(i: Int, s: String)
+object SealedClass {
+  implicit val rw: RW[SealedClass] = upickle.default.macroRW
+}
+
 case class KeyedPerson(
                    @upickle.implicits.key("first_name") firstName: String = "N/A",
                    @upickle.implicits.key("last_name") lastName: String)
@@ -871,6 +876,10 @@ object MacroTests extends TestSuite {
         """{"_tag": "Bar", "x": 123}"""
       )
 
+    }
+
+    test("sealedClass"){
+      assert(write(SealedClass(3, "Hello")) == """{"$type":"SealedClass","i":3,"s":"Hello"}""")
     }
   }
 }


### PR DESCRIPTION
Fixes #628

 Sealed classes can be instantiated directly. Therefore, when generating the typeTag, I included the sealed class itself. This ensures that the macro correctly handles sealed classes without subclasses. To check whether it’s a sealed class and not a trait or abstract class, I used the following condition:
 ```
 sealedParents.find(_ == tpe.typeSymbol)
```
Since `trait` and `abstract class` cannot be instantiated, I believe this approach works. However, I could also explicitly check that the symbol is not a trait or an abstract class, if needed.

What do you think?
