### PR TITLE
Try to build on 3.3.4

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -18,7 +18,7 @@ val scala212  = "2.12.18"
 val scala213  = "2.13.11"
 
 val scala3   = "3.3.4"
-val scalaNative = "0.5.0"
+val scalaNative = "0.5.5"
 val acyclic = "0.3.12"
 
 val sourcecode = "0.4.2"

--- a/build.sc
+++ b/build.sc
@@ -17,7 +17,7 @@ import com.github.lolgab.mill.mima._
 val scala212  = "2.12.18"
 val scala213  = "2.13.11"
 
-val scala3   = "3.4.2"
+val scala3   = "3.3.4"
 val scalaNative = "0.5.0"
 val acyclic = "0.3.12"
 


### PR DESCRIPTION
If this works, it gives uPickle and Ammonite a path to supporting Scala 3.3.x again