### PR TITLE
Use primary constructor instead of apply when create case class

### DIFF
--- a/upickle/implicits/src-2/upickle/implicits/internal/Macros.scala
+++ b/upickle/implicits/src-2/upickle/implicits/internal/Macros.scala
@@ -170,14 +170,14 @@ object Macros {
 
           def func(t: Type) = {
 
-            if (argSyms.length == 0) t
+            if (argSyms.isEmpty) t
             else {
               val concrete = tpe.normalize.asInstanceOf[TypeRef].args
               if (t.typeSymbol != definitions.RepeatedParamClass) {
 
                 t.substituteTypes(typeParams, concrete)
               } else {
-                val TypeRef(pref, sym, args) = typeOf[Seq[Int]]
+                val TypeRef(pref, sym, _) = typeOf[Seq[Int]]
                 import compat._
                 TypeRef(pref, sym, t.asInstanceOf[TypeRef].args)
               }
@@ -301,6 +301,7 @@ object Macros {
 
       val localReaders = for (i <- rawArgs.indices) yield TermName("localReader" + i)
       val aggregates = for (i <- rawArgs.indices) yield TermName("aggregated" + i)
+      val typeTreeOfClass: c.Tree = c.universe.TypeTree(targetType)
       q"""
         ..${
           for (i <- rawArgs.indices)
@@ -355,7 +356,7 @@ object Macros {
               }){
                 this.errorMissingKeys(${rawArgs.length}, ${mappedArgs.toArray})
               }
-              $companion.apply(
+              new $typeTreeOfClass(
                 ..${
                   for(i <- rawArgs.indices)
                   yield

--- a/upickle/test/src/upickle/MacroTests.scala
+++ b/upickle/test/src/upickle/MacroTests.scala
@@ -144,6 +144,23 @@ object TagName{
   implicit val quxRw: TagNamePickler.ReadWriter[Qux] = TagNamePickler.macroRW
   implicit val fooRw: TagNamePickler.ReadWriter[Foo] = TagNamePickler.macroRW
 }
+
+
+// Defined for compilation test
+sealed trait Term
+
+case class Var(name: String) extends Term
+object Var {
+  def apply(name: String): Term = new Var(name)
+  implicit val rw: RW[Var] = upickle.default.macroRW
+}
+
+case class Constant(value: Int) extends Term
+object Constant {
+  def apply(value: Int): Term = new Constant(value)
+  implicit val rw: RW[Constant] = upickle.default.macroRW
+}
+
 object MacroTests extends TestSuite {
 
   // Doesn't work :(


### PR DESCRIPTION
fixes #624

When creating a `Reader` for a case class with a custom apply method, the process can fail if the apply method returns a different type than the case class itself. To address this, I’ve modified the macro to use the primary constructor instead.