### PR TITLE
WIP: Named tuples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ out/
 *.iml
 .idea
 .DS_Store
+.bloop
+.metals

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.watcherExclude": {
+    "**/target": true
+  }
+}

--- a/build.mill
+++ b/build.mill
@@ -391,26 +391,23 @@ trait BenchModule extends CommonPlatformModule{
 object upickle_named_tuples extends Module {
   // todo: replace with scala3 version when upickle moves to next LTS
   val scalaVersionWithNamedTuples = Seq("3.6.1")
-  trait CommonCoreModule extends CommonPublishModule {
-    def ivyDeps = Agg(ivy"com.lihaoyi::geny::1.1.1")
-  }
 
   object js extends Cross[CoreJsModule](scalaVersionWithNamedTuples)
-  trait CoreJsModule extends CommonJsModule with CommonCoreModule {
+  trait CoreJsModule extends CommonJsModule with upickle.core.CommonCoreModule {
     override def scalaVersion: Target[String] = scalaVersionWithNamedTuples.head
     override def moduleDeps: Seq[PublishModule] = Seq(upickle.core.js())
     object test extends CommonTestModule
   }
 
   object jvm extends Cross[CoreJvmModule](scalaVersionWithNamedTuples)
-  trait CoreJvmModule extends CommonJvmModule with CommonCoreModule{
+  trait CoreJvmModule extends CommonJvmModule with upickle.core.CommonCoreModule{
     override def scalaVersion: Target[String] = scalaVersionWithNamedTuples.head
     override def moduleDeps: Seq[PublishModule] = Seq(upickle.core.jvm())
     object test extends CommonTestModule
   }
 
   object native extends Cross[CoreNativeModule](scalaVersionWithNamedTuples)
-  trait CoreNativeModule extends CommonNativeModule with CommonCoreModule {
+  trait CoreNativeModule extends CommonNativeModule with upickle.core.CommonCoreModule {
     override def scalaVersion: Target[String] = scalaVersionWithNamedTuples.head
     object test extends CommonTestModule
   }

--- a/build.mill
+++ b/build.mill
@@ -227,7 +227,7 @@ object ujson extends Module{
   }
 }
 
-object upickle extends Module{  
+object upickle extends Module{
   object core extends Module {
     trait CommonCoreModule extends CommonPublishModule {
       def ivyDeps = Agg(ivy"com.lihaoyi::geny::1.1.1")
@@ -386,6 +386,34 @@ trait BenchModule extends CommonPlatformModule{
     ivy"org.json4s::json4s-ast:3.6.12",
     ivy"com.lihaoyi::sourcecode::$sourcecode",
   )
+}
+
+object upickle_named_tuples extends Module {
+  // todo: replace with scala3 version when upickle moves to next LTS
+  val scalaVersionWithNamedTuples = Seq("3.6.1")
+  trait CommonCoreModule extends CommonPublishModule {
+    def ivyDeps = Agg(ivy"com.lihaoyi::geny::1.1.1")
+  }
+
+  object js extends Cross[CoreJsModule](scalaVersionWithNamedTuples)
+  trait CoreJsModule extends CommonJsModule with CommonCoreModule {
+    override def scalaVersion: Target[String] = scalaVersionWithNamedTuples.head
+    override def moduleDeps: Seq[PublishModule] = Seq(upickle.core.js())
+    object test extends CommonTestModule
+  }
+
+  object jvm extends Cross[CoreJvmModule](scalaVersionWithNamedTuples)
+  trait CoreJvmModule extends CommonJvmModule with CommonCoreModule{
+    override def scalaVersion: Target[String] = scalaVersionWithNamedTuples.head
+    override def moduleDeps: Seq[PublishModule] = Seq(upickle.core.jvm())
+    object test extends CommonTestModule
+  }
+
+  object native extends Cross[CoreNativeModule](scalaVersionWithNamedTuples)
+  trait CoreNativeModule extends CommonNativeModule with CommonCoreModule {
+    override def scalaVersion: Target[String] = scalaVersionWithNamedTuples.head
+    object test extends CommonTestModule
+  }
 }
 
 object bench extends Module {

--- a/upickle_named_tuples/src/NamedTupleReadWriter.scala
+++ b/upickle_named_tuples/src/NamedTupleReadWriter.scala
@@ -1,0 +1,35 @@
+package upickle.nt
+
+import scala.NamedTuple.NamedTuple
+import upickle.default.*
+import ujson.Value
+
+object NamedTupleReadWriter:
+  inline given [N <: Tuple, V <: Tuple, T <: NamedTuple[N, V]]: ReadWriter[T] =
+    val names = scala.compiletime.constValueTuple[N].toList.asInstanceOf[List[String]]
+    val readWriters = scala.compiletime.summonAll[Tuple.Map[V, ReadWriter]].toList.asInstanceOf[List[ReadWriter[?]]]
+
+    def toMap(t: T): Map[String, Value] =
+      val values = t.toTuple.productIterator.toList
+      (0.until(names.length)).foldLeft(Map.empty[String, Value]): (map, i) =>
+        val readWriter = readWriters(i).asInstanceOf[ReadWriter[Any]]
+        map + (names(i) -> transform(values(i))(using readWriter).to(ujson.Value))
+    end toMap
+
+    def fromMap(map: Map[String, Value]): T =
+      val namesAndRWs = names.zip(readWriters)
+      val valueList = namesAndRWs.map: (name, rw) =>
+        map.get(name) match
+          case None => throw new Exception(s"Missing field: $name")
+          case Some(v) =>
+            read(v)(using rw.asInstanceOf[ReadWriter[Any]])
+
+      val tuple = valueList.foldRight(EmptyTuple: Tuple): (v, tuple) =>
+        v *: tuple
+
+      tuple.asInstanceOf[T]
+    end fromMap
+
+    summon[ReadWriter[Map[String, Value]]].bimap(toMap, fromMap)
+  end given
+end NamedTupleReadWriter

--- a/upickle_named_tuples/test/src/PrimitiveTests.scala
+++ b/upickle_named_tuples/test/src/PrimitiveTests.scala
@@ -1,0 +1,14 @@
+package upickle
+import utest._
+import upickle.default.{read, write, readBinary, writeBinary, writeMsg, transform}
+import TestUtil._
+
+object NamedTupleTests extends TestSuite {
+
+  def tests = Tests {
+    test("Unit"){
+      rw((), "null", "{}", upack.Null, upack.Obj())
+    }
+
+  }
+}


### PR DESCRIPTION
Compiling fails with this;

```
[1/1] show
[1-148/162] upickle_named_tuples.jvm[3.6.1].compile
[1-148] [info] compiling 1 Scala source to /Users/simon/Code/upickle/out/upickle_named_tuples/jvm/3.6.1/compile.dest/classes ...
[1-148] [error] -- [E008] Not Found Error: /Users/simon/Code/upickle/upickle_named_tuples/src/NamedTupleReadWriter.scala:4:15 
[1-148] [error] 4 |import upickle.default.*
[1-148] [error]   |       ^^^^^^^^^^^^^^^
[1-148] [error]   |       value default is not a member of upickle
[1-148] [error] -- [E046] Cyclic Error: /Users/simon/Code/upickle/upickle_named_tuples/src/NamedTupleReadWriter.scala:8:45 
[1-148] [error] 8 |  inline given [N <: Tuple, V <: Tuple, T <: NamedTuple[N, V]]: ReadWriter[T] =
[1-148] [error]   |                                             ^
[1-148] [error]   |                               Cyclic reference involving val <import>
[1-148] [error]   |
[1-148] [error]   |                                Run with -explain-cyclic for more details.
[1-148] [error]   |
[1-148] [error]   | longer explanation available when compiling with `-explain`
[1-148] [error] -- [E008] Not Found Error: /Users/simon/Code/upickle/upickle_named_tuples/src/NamedTupleReadWriter.scala:3:13 
[1-148] [error] 3 |import scala.NamedTuple.NamedTuple
[1-148] [error]   |       ^^^^^^^^^^^^^^^^
[1-148] [error]   |       value NamedTuple is not a member of scala
[1-148] [error] three errors found

```

Which makes me think I've stuffed up the build horridly, as it apparently doesn't resolve either pickle or named tuples. 

I can't see how tho.