### PR TITLE
Make getElemSafe throw EOFException on misuse

### DIFF
--- a/upack/src/upack/MsgPackReader.scala
+++ b/upack/src/upack/MsgPackReader.scala
@@ -8,9 +8,11 @@ class MsgPackReader(input0: Array[Byte]) extends BaseMsgPackReader {
   val srcLength = input0.length
   protected[this] final def close() = {}
 
-  // Make sure we never call this method, since it will mutate the original array,
-  // and it should not be necessary to call it if our implementation is correct.
-  override def growBuffer(until: Int): Unit = ???
+  // If we call this method, assuming our implementation is correct,
+  // we are processing a truncated input. Throw EOFException to signal this
+  // to our caller.
+  override def growBuffer(until: Int): Unit =
+    throw new java.io.EOFException(s"index $until is outside the range of input byte array (length $srcLength)")
 
   def readDataIntoBuffer(buffer: Array[Byte], bufferOffset: Int) = {
     if(buffer == null) (input0, false, srcLength)

--- a/upack/test/src/upack/UnitTests.scala
+++ b/upack/test/src/upack/UnitTests.scala
@@ -105,14 +105,18 @@ object UnitTests extends TestSuite{
       val bytes = upack.write(msg)
       val truncatedBytes = bytes.take(2)
 
-      // Uses upack.MsgPackReader (which has its own growBuffer override that throws)
-      intercept[java.io.EOFException]{
-        upack.read(truncatedBytes)
+      // upack.MsgPackReader has its own growBuffer override that throws
+      test("upack.MsgPackReader"){
+        intercept[java.io.EOFException]{
+          upack.read(truncatedBytes) ==> msg
+        }
       }
-      // Uses upack.InputStreamMsgPackReader (BufferingElemParser semantics)
-      intercept[java.io.EOFException]{
-        val in = new ByteArrayInputStream(truncatedBytes)
-        upack.read(in)
+      // upack.InputStreamMsgPackReader uses BufferingElemParser semantics
+      test("upack.InputStreamMsgPackReader"){
+        intercept[java.io.EOFException]{
+          val in = new ByteArrayInputStream(truncatedBytes)
+          upack.read(in) ==> msg
+        }
       }
     }
   }

--- a/upack/test/src/upack/UnitTests.scala
+++ b/upack/test/src/upack/UnitTests.scala
@@ -96,8 +96,23 @@ object UnitTests extends TestSuite{
       readOne() ==> upack.Int32(2)
       readOne() ==> upack.Int32(3)
       readOne() ==> upack.Int32(4)
-      intercept[java.io.EOFException] {
+      intercept[java.io.EOFException]{
         readOne()
+      }
+    }
+    test("truncated input EOF"){
+      val msg = upack.Arr(upack.Int32(1), upack.Int32(2), upack.Int32(3), upack.Int32(4))
+      val bytes = upack.write(msg)
+      val truncatedBytes = bytes.take(2)
+
+      // Uses upack.MsgPackReader (which has its own growBuffer override that throws)
+      intercept[java.io.EOFException]{
+        upack.read(truncatedBytes)
+      }
+      // Uses upack.InputStreamMsgPackReader (BufferingElemParser semantics)
+      intercept[java.io.EOFException]{
+        val in = new ByteArrayInputStream(truncatedBytes)
+        upack.read(in)
       }
     }
   }

--- a/upack/test/src/upack/UnitTests.scala
+++ b/upack/test/src/upack/UnitTests.scala
@@ -82,5 +82,23 @@ object UnitTests extends TestSuite{
       val bytes2 = upack.write(parsed)
       assert(bytes1 sameElements bytes2)
     }
+    test("reader.parse until EOF"){
+      val msgs = List(upack.Int32(1), upack.Int32(2), upack.Int32(3), upack.Int32(4))
+      val out = new ByteArrayOutputStream()
+      msgs.foreach(_.writeBytesTo(out))
+      val bytes = out.toByteArray()
+      val in = new ByteArrayInputStream(bytes)
+      val reader = new upack.InputStreamMsgPackReader(in)
+      def readOne(): upack.Msg =
+        reader.parse(upack.Msg)
+
+      readOne() ==> upack.Int32(1)
+      readOne() ==> upack.Int32(2)
+      readOne() ==> upack.Int32(3)
+      readOne() ==> upack.Int32(4)
+      intercept[java.io.EOFException] {
+        readOne()
+      }
+    }
   }
 }

--- a/upickle/core/templates/BufferingElemParser.scala
+++ b/upickle/core/templates/BufferingElemParser.scala
@@ -57,7 +57,7 @@ trait BufferingElemParser{
 
   def getElemSafe(i: Int): Elem = {
     if(requestUntil(i)) {
-      throw java.io.EOFException(s"buffer elem $i out of range")
+      throw new java.io.EOFException(s"buffer elem $i out of range")
     }
     buffer(i - firstIdx)
   }

--- a/upickle/core/templates/BufferingElemParser.scala
+++ b/upickle/core/templates/BufferingElemParser.scala
@@ -56,7 +56,9 @@ trait BufferingElemParser{
   def getLastIdx = lastIdx
 
   def getElemSafe(i: Int): Elem = {
-    requestUntil(i)
+    if(requestUntil(i)) {
+      throw java.io.EOFException(s"buffer elem $i out of range")
+    }
     buffer(i - firstIdx)
   }
   def getElemUnsafe(i: Int): Elem = {


### PR DESCRIPTION
Fixes #672.

Without the change to BufferingElemParser, the test will misread int 0 when it goes beyond the end of the input array.
Adding a bounds check lets us see an exception indicating the true situation, rather than reading corrupt data.

This change makes parsing concatenated sequences of MsgPack values possible without a tricky workaround.
It should not affect usage where only one MsgPack value is expected.

The one possible change this may cause for users is when parsing a truncated MsgPack value, in which case upack should more reliably throw `java.io.EOFException`, rather than some implementation related error, or in some theoretical scenario, parse a corrupted MsgPack value (I can add a test for this if that's of interest).

I'm also hoping CI will run on this and expose any issues with Scala Native or Scala JS - I had issues testing those locally.