### PR TITLE
chore: Avoid another look up in LinkedHashMap#iterator

### DIFF
--- a/upickle/core/src/upickle/core/LinkedHashMap.scala
+++ b/upickle/core/src/upickle/core/LinkedHashMap.scala
@@ -22,12 +22,12 @@ class LinkedHashMap[K, V] private (underlying: ju.LinkedHashMap[K, V])
     this
   }
   def iterator: Iterator[(K, V)] = {
-    val it = underlying.keySet().iterator()
     new Iterator[(K, V)] {
+      val it = underlying.entrySet().iterator()
       def hasNext: Boolean = it.hasNext()
       def next(): (K, V) = {
-        val key = it.next()
-        key -> underlying.get(key)
+        val entry = it.next()
+        (entry.getKey, entry.getValue)
       }
     }
   }


### PR DESCRIPTION
Motivation:
Refs: https://github.com/com-lihaoyi/upickle/issues/685
Avoid another value look-up.

Modification:
Iterating on `entrySet` directly.

Result:
Better performance.