### PR TITLE
chore: Override size method in LinkedHashMap

### DIFF
--- a/upickle/core/src/upickle/core/LinkedHashMap.scala
+++ b/upickle/core/src/upickle/core/LinkedHashMap.scala
@@ -21,7 +21,7 @@ class LinkedHashMap[K, V] private (underlying: ju.LinkedHashMap[K, V])
     _put(elem._1, elem._2)
     this
   }
-  def size: Int = underlying.size
+  override def size: Int = underlying.size
   def iterator: Iterator[(K, V)] = {
     new Iterator[(K, V)] {
       val it = underlying.entrySet().iterator()

--- a/upickle/core/src/upickle/core/LinkedHashMap.scala
+++ b/upickle/core/src/upickle/core/LinkedHashMap.scala
@@ -21,6 +21,7 @@ class LinkedHashMap[K, V] private (underlying: ju.LinkedHashMap[K, V])
     _put(elem._1, elem._2)
     this
   }
+  def size: Int = underlying.size
   def iterator: Iterator[(K, V)] = {
     new Iterator[(K, V)] {
       val it = underlying.entrySet().iterator()


### PR DESCRIPTION
Motivation:
In sjsonnet, where I want to avoid array copy with pre-allocated `Array`, which need to access the size of ujson's `LinkedHashMap`'s `size()` method, by default, it will iterate the iterator to accumulate the size.
But the underlying Java's `LinkedHashMap` has a dedicated field to get the size, so we now avoid the `O(n)` iteration to a simple field read.

Modification:
Override the method `size` to make use of the underlying Java's linkedHashMap's `size()` method.

Result:
Better performance.
